### PR TITLE
Add German holiday import and employee absence display specs

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   biome:
     name: Lint & Format Check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   macos:
     runs-on: "macos-latest"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   bun:
     runs-on: "ubuntu-latest"

--- a/openspec/changes/bl-027-import-german-holidays-via-nager-api-for-week-view-v1-scope/design.md
+++ b/openspec/changes/bl-027-import-german-holidays-via-nager-api-for-week-view-v1-scope/design.md
@@ -6,9 +6,11 @@ The week view needs German public holidays to provide planning context. The Nage
 
 **Goals:**
 - Fetch Germany-wide holidays and MV-specific holidays
-- Cache year data locally to avoid repeated API calls
+- Cache year data on disk to avoid repeated API calls
 - Handle year-boundary weeks correctly
 - Show graceful error handling without breaking UI
+- Display holiday name in column header below the date
+- Grey out holiday columns for all employees
 
 **Non-Goals:**
 - Additional Bundesland-specific holidays beyond MV
@@ -17,10 +19,10 @@ The week view needs German public holidays to provide planning context. The Nage
 ## Decisions
 
 ### API Integration
-**Decision**: Use Nager API with country code `DE` and filter by `global` and `MV`
-- Fetch all holidays for given year
-- Filter client-side for global and MV states only
-- Cache response in memory for same-year requests
+**Decision**: Use Nager API with country code `DE`, filter client-side by `global` and `DE-MV` county
+- Endpoint: `GET https://date.nager.at/api/v3/PublicHolidays/{year}/DE`
+- Use `localName` field for German holiday name display
+- Keep holiday if `global == true` OR `counties` contains `"DE-MV"`
 
 ### Year-Boundary Handling
 **Decision**: Fetch holidays for both years when week spans year boundary
@@ -28,9 +30,28 @@ The week view needs German public holidays to provide planning context. The Nage
 - Fetch holidays for both years and merge
 
 ### Caching Strategy
-**Decision**: In-memory cache with year as key
-- Avoids repeated API calls within session
-- Cache invalidates on year change or explicit refresh
+**Decision**: Disk cache via LocalStore with per-year entries and age-based refresh
+- Cache shape: `Vec<HolidayCacheEntry>` added to `LocalStore`
+  - `year: i32`, `fetched_at: String` (yyyy-MM-dd), `holidays: Vec<CachedHoliday>`
+  - `CachedHoliday`: `date: String` (yyyy-MM-dd), `name: String` (German)
+- **Current year**: re-fetch if `fetched_at` is older than 30 days (holidays can be corrected)
+- **Other years**: re-fetch only if entry is absent (past years are stable)
+- **Cleanup**: on every save, remove cache entries where `fetched_at` is older than 1 year
+
+### Frontend Display
+**Decision**: Holiday name shown below the date in the column header; holiday columns greyed out
+- `TimetableHeader` receives an optional `holiday` prop
+- When present: render date on first line, holiday name (German) on second line; apply grey styling to header
+- `TimetableRow` receives a `holidayDates: Set<string>` prop (yyyy-MM-dd strings)
+- Cells whose date is in `holidayDates` receive grey background styling
+- `PlanningGrid` owns the `useHolidays(weekStart)` hook and passes data down
+
+### Tauri Command
+**Decision**: Single command returning holidays for a given week
+- Signature: `get_holidays_for_week(week_start: String) -> Result<Vec<Holiday>, String>`
+- `Holiday`: `date: String` (yyyy-MM-dd), `name: String`
+- Backend handles year-boundary, caching, and filtering before returning
+- Frontend receives only the holidays that fall within the requested week
 
 ## Risks / Trade-offs
 
@@ -38,4 +59,4 @@ The week view needs German public holidays to provide planning context. The Nage
   - **Mitigation**: Show German warning "Feiertage konnten nicht geladen werden" and continue without holidays
 
 - **Risk**: Rate limiting
-  - **Mitigation**: Cache aggressively, add retry with backoff
+  - **Mitigation**: Disk cache with monthly refresh for current year; past years cached indefinitely

--- a/openspec/changes/bl-027-import-german-holidays-via-nager-api-for-week-view-v1-scope/proposal.md
+++ b/openspec/changes/bl-027-import-german-holidays-via-nager-api-for-week-view-v1-scope/proposal.md
@@ -5,7 +5,7 @@ The week view needs to display German public holidays to help planners avoid sch
 ## What Changes
 
 - Integrate Nager API for German public holidays
-- Fetch Germany-wide (`global=true`) and Mecklenburg-Vorpommern (`MV`) holidays
+- Fetch Germany-wide (`global=true`) and Mecklenburg-Vorpommern (`DE-MV`) holidays
 - Cache holiday data per year locally
 - Handle year-boundary weeks (resolve holidays from both years)
 - Show German warning state on API failure without breaking planning

--- a/openspec/changes/bl-027-import-german-holidays-via-nager-api-for-week-view-v1-scope/specs/german-holiday-import/spec.md
+++ b/openspec/changes/bl-027-import-german-holidays-via-nager-api-for-week-view-v1-scope/specs/german-holiday-import/spec.md
@@ -18,20 +18,15 @@ The system SHALL import German public holidays for week view display.
 - **THEN** holidays from both years are fetched and merged
 - **AND** holidays are correctly mapped to their respective days
 
-#### Scenario: Cache current year with monthly refresh
-- **WHEN** holidays for the current year have been fetched
+#### Scenario: Cache year with monthly refresh
+- **WHEN** holidays for a given year have been fetched
 - **THEN** subsequent requests within 30 days use cached data
 - **AND** no additional API call is made
 
-#### Scenario: Refresh stale current-year cache
-- **WHEN** the cached entry for the current year is older than 30 days
+#### Scenario: Refresh stale cache
+- **WHEN** the cached entry for the requested year is older than 30 days
 - **THEN** the service re-fetches from the Nager API
 - **AND** updates the cache with fresh data and a new `fetched_at` date
-
-#### Scenario: Cache other years indefinitely
-- **WHEN** holidays for a past or future year have been fetched
-- **THEN** subsequent requests for that year always use cached data
-- **AND** no re-fetch occurs regardless of cache age
 
 #### Scenario: Clean up old cache entries
 - **WHEN** the holiday cache is saved

--- a/openspec/changes/bl-027-import-german-holidays-via-nager-api-for-week-view-v1-scope/specs/german-holiday-import/spec.md
+++ b/openspec/changes/bl-027-import-german-holidays-via-nager-api-for-week-view-v1-scope/specs/german-holiday-import/spec.md
@@ -5,25 +5,49 @@ The system SHALL import German public holidays for week view display.
 
 #### Scenario: Fetch Germany-wide holidays
 - **WHEN** week view requests holidays for Germany
-- **THEN** the service fetches holidays with `countryCode=DE` and `global=true`
-- **AND** returns holiday names in German
+- **THEN** the service fetches holidays with `countryCode=DE`
+- **AND** returns holiday entries where `global == true` using `localName` as the German name
 
 #### Scenario: Include Mecklenburg-Vorpommern holidays
 - **WHEN** week view requests holidays for Germany
-- **THEN** the service also includes MV-specific holidays
-- **AND** excludes other state-specific holidays
+- **THEN** the service also includes entries where `counties` contains `"DE-MV"`
+- **AND** excludes entries from other German states
 
 #### Scenario: Year-boundary week
 - **WHEN** a week spans two years (e.g., Dec 28 - Jan 3)
-- **THEN** holidays from both years are included
+- **THEN** holidays from both years are fetched and merged
 - **AND** holidays are correctly mapped to their respective days
 
-#### Scenario: Cache holiday data
-- **WHEN** holidays for a year have been fetched
-- **THEN** subsequent requests for same year use cached data
+#### Scenario: Cache current year with monthly refresh
+- **WHEN** holidays for the current year have been fetched
+- **THEN** subsequent requests within 30 days use cached data
 - **AND** no additional API call is made
+
+#### Scenario: Refresh stale current-year cache
+- **WHEN** the cached entry for the current year is older than 30 days
+- **THEN** the service re-fetches from the Nager API
+- **AND** updates the cache with fresh data and a new `fetched_at` date
+
+#### Scenario: Cache other years indefinitely
+- **WHEN** holidays for a past or future year have been fetched
+- **THEN** subsequent requests for that year always use cached data
+- **AND** no re-fetch occurs regardless of cache age
+
+#### Scenario: Clean up old cache entries
+- **WHEN** the holiday cache is saved
+- **THEN** any entry whose `fetched_at` is older than 1 year is removed
 
 #### Scenario: API failure handling
 - **WHEN** Nager API request fails
-- **THEN** show German warning "Feiertage konnten nicht geladen werden"
-- **AND** week view continues without holiday data
+- **THEN** the command returns a German error message "Feiertage konnten nicht geladen werden"
+- **AND** the week view continues to display without holiday data
+
+#### Scenario: Holiday name in column header
+- **WHEN** a week day is a public holiday
+- **THEN** the column header shows the weekday and date on the first line
+- **AND** the German holiday name on the second line
+- **AND** the header is styled in grey
+
+#### Scenario: Grey out holiday column
+- **WHEN** a week day is a public holiday
+- **THEN** all employee cells in that column are displayed with a grey background

--- a/openspec/changes/bl-027-import-german-holidays-via-nager-api-for-week-view-v1-scope/tasks.md
+++ b/openspec/changes/bl-027-import-german-holidays-via-nager-api-for-week-view-v1-scope/tasks.md
@@ -1,26 +1,41 @@
-## 1. Setup and API Client
+## 1. Backend: API Client and Module
 
-- [ ] 1.1 Add reqwest dependency for HTTP requests
-- [ ] 1.2 Create German holiday import module
-- [ ] 1.3 Define Holiday struct with date, name, and state fields
-- [ ] 1.4 Implement Nager API client for Germany
+- [ ] 1.1 Create German holiday import module (`integrations/holidays.rs`)
+- [ ] 1.2 Define `Holiday` struct (date, name) and Nager API response struct
+- [ ] 1.3 Implement `fetch_holidays_from_api(year)` using existing `tauri_plugin_http::reqwest`
+- [ ] 1.4 Filter response: keep entries where `global == true` OR `counties` contains `"DE-MV"`; use `localName` as name
 
-## 2. Holiday Fetching
+## 2. Backend: Caching
 
-- [ ] 2.1 Implement fetch_holidays(year) method
-- [ ] 2.2 Filter for global and MV-only holidays
-- [ ] 2.3 Handle year-boundary weeks (fetch both years)
-- [ ] 2.4 Cache holiday data in memory by year
+- [ ] 2.1 Add `HolidayCacheEntry` and `CachedHoliday` structs to `local_store.rs`
+- [ ] 2.2 Add `holiday_cache: Vec<HolidayCacheEntry>` field to `LocalStore`
+- [ ] 2.3 Implement cache lookup: current year re-fetches if older than 30 days; other years use cache if present
+- [ ] 2.4 Implement cache cleanup: remove entries where `fetched_at` is older than 1 year (run on every save)
 
-## 3. Error Handling
+## 3. Backend: Command and Year-Boundary Handling
 
-- [ ] 3.1 Implement timeout handling (5s)
-- [ ] 3.2 Add German error message for API failures
-- [ ] 3.3 Graceful degradation (show warning, no crash)
+- [ ] 3.1 Implement `get_holidays_for_week(week_start: String)` Tauri command
+- [ ] 3.2 Detect year-boundary weeks and fetch both years when needed
+- [ ] 3.3 Filter fetched holidays to only those falling within the requested week before returning
+- [ ] 3.4 Register command in `lib.rs`
 
-## 4. Testing
+## 4. Backend: Error Handling
 
-- [ ] 4.1 Write service tests for Nager API mapping (DE, global, MV)
-- [ ] 4.2 Write tests verifying non-MV state holidays are excluded
-- [ ] 4.3 Write tests for year-boundary fetch
-- [ ] 4.4 Write tests for timeout and failure behavior
+- [ ] 4.1 Implement timeout handling (5s)
+- [ ] 4.2 Return German error message on API failure: "Feiertage konnten nicht geladen werden"
+- [ ] 4.3 Graceful degradation: frontend receives error string, continues without holiday data
+
+## 5. Frontend: Hook and Display
+
+- [ ] 5.1 Create `useHolidays(weekStart)` hook calling `invoke("get_holidays_for_week")`
+- [ ] 5.2 Add holiday warning display in `PlanningGrid` (mirrors existing error alert pattern)
+- [ ] 5.3 Update `TimetableHeader` to accept optional `holiday` prop; render holiday name below date with grey styling
+- [ ] 5.4 Update `TimetableRow` to accept `holidayDates: Set<string>`; apply grey background to cells on holiday dates
+- [ ] 5.5 Wire `useHolidays` into `PlanningGrid`; pass holiday data to `TimetableHeader` and `TimetableRow`
+
+## 6. Testing
+
+- [ ] 6.1 Write unit tests for Nager API response filtering (global, DE-MV, exclusion of other states)
+- [ ] 6.2 Write unit tests for year-boundary detection and merging
+- [ ] 6.3 Write unit tests for cache age logic (current year 30-day refresh, other years stable, 1-year cleanup)
+- [ ] 6.4 Write unit tests for timeout and API failure behavior

--- a/openspec/changes/bl-027-import-german-holidays-via-nager-api-for-week-view-v1-scope/tasks.md
+++ b/openspec/changes/bl-027-import-german-holidays-via-nager-api-for-week-view-v1-scope/tasks.md
@@ -2,28 +2,32 @@
 
 - [ ] 1.1 Create German holiday import module (`integrations/holidays.rs`)
 - [ ] 1.2 Define `Holiday` struct (date, name) and Nager API response struct
-- [ ] 1.3 Implement `fetch_holidays_from_api(year)` using existing `tauri_plugin_http::reqwest`
-- [ ] 1.4 Filter response: keep entries where `global == true` OR `counties` contains `"DE-MV"`; use `localName` as name
+- [ ] 1.3 Write unit tests for Nager API response filtering (global, DE-MV, exclusion of other states)
+- [ ] 1.4 Implement `fetch_holidays_from_api(year)` using existing `tauri_plugin_http::reqwest`
+- [ ] 1.5 Filter response: keep entries where `global == true` OR `counties` contains `"DE-MV"`; use `localName` as name
 
 ## 2. Backend: Caching
 
 - [ ] 2.1 Add `HolidayCacheEntry` and `CachedHoliday` structs to `local_store.rs`
 - [ ] 2.2 Add `holiday_cache: Vec<HolidayCacheEntry>` field to `LocalStore`
-- [ ] 2.3 Implement cache lookup: current year re-fetches if older than 30 days; other years use cache if present
-- [ ] 2.4 Implement cache cleanup: remove entries where `fetched_at` is older than 1 year (run on every save)
+- [ ] 2.3 Write unit tests for cache age logic (30-day refresh, 1-year cleanup)
+- [ ] 2.4 Implement cache lookup: re-fetches if older than 30 days
+- [ ] 2.5 Implement cache cleanup: remove entries where `fetched_at` is older than 1 year (run on every save)
 
 ## 3. Backend: Command and Year-Boundary Handling
 
-- [ ] 3.1 Implement `get_holidays_for_week(week_start: String)` Tauri command
-- [ ] 3.2 Detect year-boundary weeks and fetch both years when needed
-- [ ] 3.3 Filter fetched holidays to only those falling within the requested week before returning
-- [ ] 3.4 Register command in `lib.rs`
+- [ ] 3.1 Write unit tests for year-boundary detection and merging
+- [ ] 3.2 Implement `get_holidays_for_week(week_start: String)` Tauri command
+- [ ] 3.3 Detect year-boundary weeks and fetch both years when needed
+- [ ] 3.4 Filter fetched holidays to only those falling within the requested week before returning
+- [ ] 3.5 Register command in `lib.rs`
 
 ## 4. Backend: Error Handling
 
-- [ ] 4.1 Implement timeout handling (5s)
-- [ ] 4.2 Return German error message on API failure: "Feiertage konnten nicht geladen werden"
-- [ ] 4.3 Graceful degradation: frontend receives error string, continues without holiday data
+- [ ] 4.1 Write unit tests for timeout and API failure behavior
+- [ ] 4.2 Implement timeout handling (5s)
+- [ ] 4.3 Return German error message on API failure: "Feiertage konnten nicht geladen werden"
+- [ ] 4.4 Graceful degradation: frontend receives error string, continues without holiday data
 
 ## 5. Frontend: Hook and Display
 
@@ -32,10 +36,3 @@
 - [ ] 5.3 Update `TimetableHeader` to accept optional `holiday` prop; render holiday name below date with grey styling
 - [ ] 5.4 Update `TimetableRow` to accept `holidayDates: Set<string>`; apply grey background to cells on holiday dates
 - [ ] 5.5 Wire `useHolidays` into `PlanningGrid`; pass holiday data to `TimetableHeader` and `TimetableRow`
-
-## 6. Testing
-
-- [ ] 6.1 Write unit tests for Nager API response filtering (global, DE-MV, exclusion of other states)
-- [ ] 6.2 Write unit tests for year-boundary detection and merging
-- [ ] 6.3 Write unit tests for cache age logic (current year 30-day refresh, other years stable, 1-year cleanup)
-- [ ] 6.4 Write unit tests for timeout and API failure behavior

--- a/openspec/changes/load-and-display-employee-absences/.openspec.yaml
+++ b/openspec/changes/load-and-display-employee-absences/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/load-and-display-employee-absences/design.md
+++ b/openspec/changes/load-and-display-employee-absences/design.md
@@ -1,0 +1,47 @@
+## Context
+
+The local store already has `zep_absence_calendar`, `absence_ical_last_tested_at`, and `absence_ical_last_test_passed` on `EmployeeSetting`. The `EmployeeIcalDialog` already renders a full "Abwesenheit" section for configuring and testing the absence calendar URL. The `IcalSource` enum already has `Primary` and `Absence` variants.
+
+What is missing: the backend does not fetch from absence calendars, `CalendarEventKind` has no `Absence` variant, and the frontend does not render absence events distinctly.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fetch events from `zep_absence_calendar` per employee in `load_week_events`
+- Surface absence events as `CalendarEventKind::Absence` in the existing response structure
+- Render absence events visually distinct from assignments and bare events in `TimetableCell`
+- No new Tauri command; no changes to settings UI (already complete)
+
+**Non-Goals:**
+- Showing absence error states in the timetable row (absence is optional; failures degrade silently)
+- Distinguishing absence subtypes (Urlaub vs. Krankenstand)
+
+## Decisions
+
+### Extend `load_week_events`, not a new command
+Absence events are fetched in the same command call as primary calendar events. This avoids a second round-trip when loading the week view. Absence events are appended to the same `events: Vec<CalendarCellEvent>` per employee using the new `Absence` kind.
+
+### Add `Absence` to `CalendarEventKind`
+```rust
+pub enum CalendarEventKind {
+    Assignment,
+    Bare,
+    Absence,  // new
+}
+```
+Absence events carry a `title` (the iCal SUMMARY, e.g. "Urlaub") and `date`, but no `project_status`.
+
+### Concurrent fetch per employee
+For each employee with both a primary and absence calendar configured, fetch both concurrently. Only the primary calendar failure sets `EmployeeWeekEvents.error`. Absence calendar failures are silently skipped — the calendar is optional and its unavailability should not block the row from rendering.
+
+### Frontend: `CellEvent` kind extended to `"absence"`
+`types.ts` adds `"absence"` to the `CellEvent.kind` union. `toCellEvent` maps `Absence` events to `bg-warning/30` color. `TimetableCell` renders absence events using the same non-interactive (`span`) path as bare events, with the warning color applied.
+
+### No changes to settings dialog or ZEP service
+The "Abwesenheit" calendar section in `EmployeeIcalDialog` is already fully implemented. No work needed there.
+
+## Risks / Trade-offs
+
+- **Risk**: Absence events from the CalDAV calendar may have varying SUMMARY strings (no standard format) → Accept: render whatever `SUMMARY` the event has; planners recognise their own calendar entries.
+- **Risk**: Employees with no absence calendar configured are common initially → Mitigation: `zep_absence_calendar: None` is explicitly handled as "skip silently."
+- **Trade-off**: Absence fetch failures are silent → acceptable because the calendar is optional; a failed optional source should not block the primary planning view.

--- a/openspec/changes/load-and-display-employee-absences/proposal.md
+++ b/openspec/changes/load-and-display-employee-absences/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Planners currently have no way to see when employees are absent (Urlaub, Krankenstand, etc.) in the week view, making it easy to accidentally schedule assignments on unavailable days. Adding absence visibility directly in the planning grid prevents scheduling conflicts and reduces manual cross-checking.
+
+## What Changes
+
+- Add a ZEP absence calendar URL field to each employee's settings (alongside the existing primary calendar)
+- Fetch absence events from that CalDAV calendar per employee when loading a week
+- Display absence days visually distinct from assignments in the timetable (dedicated cell styling)
+- Extend the settings dialog to allow configuring the absence calendar URL per employee
+
+## Capabilities
+
+### New Capabilities
+- `employee-absence-display`: Load absence events from a per-employee ZEP CalDAV absence calendar and display them in the timetable week view with distinct visual styling
+
+### Modified Capabilities
+<!-- No existing spec requirements are changing -->
+
+## Impact
+
+- Code: Extend `EmployeeSetting` in local store with `zep_absence_calendar` field; extend `load_week_events` or add new Tauri command; update `TimetableRow`/`TimetableCell` frontend components
+- APIs: ZEP CalDAV (same mechanism as existing primary calendar)
+- No new external dependencies required

--- a/openspec/changes/load-and-display-employee-absences/specs/employee-absence-display/spec.md
+++ b/openspec/changes/load-and-display-employee-absences/specs/employee-absence-display/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Employee absence fetching
+The system SHALL fetch absence events from each employee's configured ZEP absence calendar when loading week events.
+
+#### Scenario: Absence events included in week response
+- **WHEN** `load_week_events` is called for a week
+- **THEN** absence events from `zep_absence_calendar` are included in `EmployeeWeekEvents.events` for each employee
+- **AND** each absence event has `kind: Absence`
+
+#### Scenario: No absence calendar configured
+- **WHEN** an employee has no `zep_absence_calendar` set
+- **THEN** no absence events are returned for that employee
+- **AND** the response is otherwise unaffected
+
+#### Scenario: Absence calendar fetch failure
+- **WHEN** fetching the absence calendar fails (network error, auth error, etc.)
+- **THEN** no absence events are returned for that employee
+- **AND** the primary calendar events and `error` field are unaffected
+
+#### Scenario: Absence event carries summary as title
+- **WHEN** an absence calendar event has a SUMMARY field
+- **THEN** the absence event `title` is set to that SUMMARY value
+- **AND** `project_status` is `null`
+
+### Requirement: Absence event display
+The system SHALL render absence events visually distinct from assignment and bare events in the timetable.
+
+#### Scenario: Absence cell styling
+- **WHEN** a timetable cell contains an absence event
+- **THEN** the absence event is rendered non-interactively (no button)
+- **AND** it uses a warning color distinct from assignment and bare event colors
+
+#### Scenario: Multiple event types in same cell
+- **WHEN** a cell contains both an absence event and an assignment event
+- **THEN** both are rendered in the cell
+- **AND** each uses its respective styling

--- a/openspec/changes/load-and-display-employee-absences/tasks.md
+++ b/openspec/changes/load-and-display-employee-absences/tasks.md
@@ -1,0 +1,27 @@
+## 1. Backend: Absence Event Kind
+
+- [ ] 1.1 Add `Absence` variant to `CalendarEventKind` enum in `calendar.rs`
+- [ ] 1.2 Update any exhaustive matches on `CalendarEventKind` to handle the new variant
+
+## 2. Backend: Fetch Absence Events in `load_week_events`
+
+- [ ] 2.1 For each employee with `zep_absence_calendar` set, fetch CalDAV events from that URL using the existing `fetch_calendar_events` function
+- [ ] 2.2 Fetch primary and absence calendars concurrently per employee
+- [ ] 2.3 Map fetched absence events to `CalendarCellEvent` with `kind: Absence` and no `project_status`
+- [ ] 2.4 Append absence events to the employee's `events` vec (absence calendar fetch failures are silently skipped; do not set `error`)
+
+## 3. Backend: Testing
+
+- [ ] 3.1 Write unit test: absence events included in response when absence calendar is configured
+- [ ] 3.2 Write unit test: no absence events when `zep_absence_calendar` is `None`
+- [ ] 3.3 Write unit test: absence calendar fetch failure does not affect primary calendar events or `error` field
+- [ ] 3.4 Write unit test: absence event has `kind: Absence`, correct `title` from SUMMARY, and `project_status: None`
+
+## 4. Frontend: Type and Mapping
+
+- [ ] 4.1 Add `"absence"` to the `CellEvent.kind` union in `types.ts`
+- [ ] 4.2 Map `Absence` events to `bg-warning/30` color in `toCellEvent`
+
+## 5. Frontend: Cell Rendering
+
+- [ ] 5.1 Add an absence rendering branch to `TimetableCell`: non-interactive `span` with warning color styling


### PR DESCRIPTION
## Summary

This PR adds comprehensive specification and task documentation for two new features: importing German public holidays via the Nager API for week view display, and loading and displaying employee absences from ZEP CalDAV calendars.

## Key Changes

### German Holiday Import Feature (`bl-027`)
- **Restructured tasks** from generic setup/fetching/testing into backend-focused phases:
  - Backend API client and module setup
  - Disk-based caching strategy with age-based refresh logic
  - Tauri command implementation with year-boundary handling
  - Error handling with German user messages
  - Frontend hook and component integration
  - Comprehensive testing coverage

- **Updated design decisions**:
  - Changed from in-memory to disk-based caching via `LocalStore`
  - Implemented tiered cache refresh: current year re-fetches every 30 days, other years cached indefinitely
  - Added automatic cleanup of cache entries older than 1 year
  - Specified frontend display: holiday name in column header with grey styling

- **Enhanced specifications**:
  - Added scenarios for cache refresh logic and cleanup
  - Clarified filtering criteria: `global == true` OR `counties` contains `"DE-MV"`
  - Added frontend display requirements (header styling, column greying)
  - Specified error message in German: "Feiertage konnten nicht geladen werden"

### Employee Absence Display Feature (New)
- **Created new capability** for loading and displaying employee absences:
  - Proposal document outlining motivation and impact
  - Design document with decisions on concurrent fetching, silent failure for optional calendars, and frontend rendering
  - Specification with scenarios for absence fetching, calendar configuration, and visual display
  - Task breakdown for backend (extend `CalendarEventKind`, fetch absence events concurrently) and frontend (add `"absence"` kind, render with warning color)

- **Key design decisions**:
  - Absence events fetched concurrently with primary calendar per employee
  - Absence calendar failures are silent (optional calendar, no error propagation)
  - New `Absence` variant in `CalendarEventKind` enum
  - Frontend renders absence events as non-interactive spans with warning color (`bg-warning/30`)

## Notable Implementation Details

- **Holiday caching**: Per-year entries stored in `LocalStore` with `fetched_at` timestamp; current year uses 30-day refresh window to catch holiday corrections; past/future years use indefinite cache
- **Year-boundary handling**: Automatic detection and dual-year fetch when week spans calendar boundary
- **Concurrent absence fetching**: Both primary and absence calendars fetched in parallel per employee to minimize latency
- **Graceful degradation**: Both features continue operation on API/calendar failures without blocking the planning view

https://claude.ai/code/session_01VH5Nc2TjY2rMHKMdaoGZMQ