### PR TITLE
Add OpenSpec proposals: weekend visibility toggle and agent E2E testing

### DIFF
--- a/openspec/changes/add-weekend-visibility-toggle/.openspec.yaml
+++ b/openspec/changes/add-weekend-visibility-toggle/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/add-weekend-visibility-toggle/design.md
+++ b/openspec/changes/add-weekend-visibility-toggle/design.md
@@ -21,8 +21,9 @@ Display preferences are already persisted via `DisplaySettings` in the local sto
 
 ### Storage: extend DisplaySettings
 **Decision**: Add `show_weekend: bool` to the Rust `DisplaySettings` struct, defaulting to `false`, and mirror it as `showWeekend: boolean` in the generated TypeScript type.
-- `DisplaySettings` has a hand-written `impl Default` (not `#[derive(Default)]`) because `hide_non_plannable_employees` defaults to `true`. The new field must be added to that manual block as `show_weekend: false`. Switching to `#[derive(Default)]` would silently reset `hide_non_plannable_employees` to `false`.
-- Follows the existing `hide_non_plannable_employees` precedent, including `#[serde(default)]`-style tolerance so older local stores without the field load as off.
+- `DisplaySettings` has a hand-written `impl Default` (not `#[derive(Default)]`) because `hide_non_plannable_employees` defaults to `true`.
+- The new field must be added to that manual block as `show_weekend: false`; switching to `#[derive(Default)]` would silently reset `hide_non_plannable_employees` to `false`.
+- The `show_weekend` field itself must carry `#[serde(default)]` so a stored `DisplaySettings` written before this field existed deserializes (the struct-level default does not fill in individual missing fields), resolving to `false`.
 - Keeps a single display-settings object rather than introducing a new persistence surface.
 
 ### Week-day generation

--- a/openspec/changes/add-weekend-visibility-toggle/design.md
+++ b/openspec/changes/add-weekend-visibility-toggle/design.md
@@ -20,8 +20,9 @@ Display preferences are already persisted via `DisplaySettings` in the local sto
 ## Decisions
 
 ### Storage: extend DisplaySettings
-**Decision**: Add `show_weekend: bool` to the Rust `DisplaySettings` struct with a `Default` of `false`, and mirror it as `showWeekend: boolean` in the generated TypeScript type.
-- Follows the existing `hide_non_plannable_employees` precedent exactly, including `#[serde(default)]`-style tolerance so older local stores without the field load as off.
+**Decision**: Add `show_weekend: bool` to the Rust `DisplaySettings` struct, defaulting to `false`, and mirror it as `showWeekend: boolean` in the generated TypeScript type.
+- `DisplaySettings` has a hand-written `impl Default` (not `#[derive(Default)]`) because `hide_non_plannable_employees` defaults to `true`. The new field must be added to that manual block as `show_weekend: false`. Switching to `#[derive(Default)]` would silently reset `hide_non_plannable_employees` to `false`.
+- Follows the existing `hide_non_plannable_employees` precedent, including `#[serde(default)]`-style tolerance so older local stores without the field load as off.
 - Keeps a single display-settings object rather than introducing a new persistence surface.
 
 ### Week-day generation
@@ -34,8 +35,19 @@ Display preferences are already persisted via `DisplaySettings` in the local sto
 **Decision**: Load `showWeekend` alongside the existing display settings in `app.tsx`, pass it into `getWeekDays`, and extend `display-settings.ts` with load/save helpers plus a `DEFAULT_SHOW_WEEKEND = false` constant.
 - The settings dialog adds a toggle mirroring the `hideNonPlannable` checkbox, labelled "Wochenende anzeigen" with a short German description.
 
+### Fix the existing overwrite bug in `saveHideNonPlannableEmployees`
+**Decision**: Change both save helpers to merge into the existing `displaySettings` rather than replacing it.
+- Today `saveHideNonPlannableEmployees` writes `displaySettings: { hideNonPlannableEmployees }`, replacing the whole object.
+- With a second field live, the helper that saves last wins and silently drops the other field's value.
+- `saveHideNonPlannableEmployees` and the new `saveShowWeekend` must both spread the loaded `displaySettings` and override only their own field.
+
 ## Risks / Trade-offs
 
-- **Risk**: Existing local stores lack the new field. **Mitigation**: serde default and a frontend default of `false` resolve missing values to off.
-- **Trade-off**: `getWeekDays` gains a parameter, touching its callers and tests. Accepted because it keeps the day list as the single source of truth for column count.
-- **Risk**: Weekend columns may surface holidays or absences not previously visible. **Mitigation**: those item types already render by date, so showing them on Saturday/Sunday is the intended behavior, not a regression.
+- **Risk**: Existing local stores lack the new field.
+  - **Mitigation**: serde default and a frontend default of `false` resolve missing values to off.
+- **Risk**: The existing `saveHideNonPlannableEmployees` overwrites the whole `displaySettings` object, so adding a second field means one save can drop the other.
+  - **Mitigation**: fix both save helpers to merge into the loaded `displaySettings`, covered by a dedicated regression test.
+- **Trade-off**: `getWeekDays` gains a parameter, touching its callers and tests.
+  - Accepted because it keeps the day list as the single source of truth for column count.
+- **Risk**: Weekend columns may surface holidays or absences not previously visible.
+  - **Mitigation**: those item types already render by date, so showing them on Saturday/Sunday is the intended behavior, not a regression.

--- a/openspec/changes/add-weekend-visibility-toggle/design.md
+++ b/openspec/changes/add-weekend-visibility-toggle/design.md
@@ -1,0 +1,41 @@
+## Context
+
+The planning view builds its columns from `getWeekDays(weekOffset)` in `src/app/util.ts`, which currently hardcodes `length: 5` to return Monday to Friday.
+The table and child components already derive their column count from `weekDays.length` (for example `colSpan={weekDays.length + 1}`), so they adapt to a variable number of days.
+
+Display preferences are already persisted via `DisplaySettings` in the local store (`src-tauri/src/integrations/local_store.rs`), exposed to the frontend through the generated `DisplaySettings` type and the `display-settings.ts` service, and toggled in the settings dialog under the "Anzeige" section (`hideNonPlannableEmployees` is the existing precedent).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a persisted `showWeekend` display setting, defaulting to off.
+- Make `getWeekDays` return Monday to Friday or Monday to Sunday based on the setting.
+- Surface the setting as a German-labelled toggle in the settings dialog, reusing the existing display-settings pattern.
+
+**Non-Goals:**
+- Per-user or per-employee weekend preferences.
+- Hiding individual weekend days independently (Saturday only, etc.).
+- Any change to weekend assignment data, holidays, or absences beyond rendering the extra columns.
+
+## Decisions
+
+### Storage: extend DisplaySettings
+**Decision**: Add `show_weekend: bool` to the Rust `DisplaySettings` struct with a `Default` of `false`, and mirror it as `showWeekend: boolean` in the generated TypeScript type.
+- Follows the existing `hide_non_plannable_employees` precedent exactly, including `#[serde(default)]`-style tolerance so older local stores without the field load as off.
+- Keeps a single display-settings object rather than introducing a new persistence surface.
+
+### Week-day generation
+**Decision**: Change `getWeekDays` to accept the weekend flag and return 5 or 7 days.
+- Signature becomes `getWeekDays(weekOffset, showWeekend)`; length is `showWeekend ? 7 : 5`.
+- Saturday and Sunday are appended after Friday, keeping Monday as the first column.
+- Downstream components need no structural change because they already key off `weekDays.length`.
+
+### Frontend wiring
+**Decision**: Load `showWeekend` alongside the existing display settings in `app.tsx`, pass it into `getWeekDays`, and extend `display-settings.ts` with load/save helpers plus a `DEFAULT_SHOW_WEEKEND = false` constant.
+- The settings dialog adds a toggle mirroring the `hideNonPlannable` checkbox, labelled "Wochenende anzeigen" with a short German description.
+
+## Risks / Trade-offs
+
+- **Risk**: Existing local stores lack the new field. **Mitigation**: serde default and a frontend default of `false` resolve missing values to off.
+- **Trade-off**: `getWeekDays` gains a parameter, touching its callers and tests. Accepted because it keeps the day list as the single source of truth for column count.
+- **Risk**: Weekend columns may surface holidays or absences not previously visible. **Mitigation**: those item types already render by date, so showing them on Saturday/Sunday is the intended behavior, not a regression.

--- a/openspec/changes/add-weekend-visibility-toggle/proposal.md
+++ b/openspec/changes/add-weekend-visibility-toggle/proposal.md
@@ -21,5 +21,6 @@ Some teams occasionally work weekends and need to see those days, while most pre
 ## Impact
 
 - Code: `getWeekDays` (week-day generation) becomes weekend-aware, the planning page reads the setting, and the settings dialog gains a toggle.
+- Behavior change: fixes an existing bug where `saveHideNonPlannableEmployees` overwrites the whole `displaySettings` object; both save helpers now merge so saving one display field no longer drops the other.
 - Storage: New `showWeekend` field on the existing `DisplaySettings` in the local store (Rust + generated TypeScript types).
 - Dependencies: Builds on the existing display-settings persistence used by `hideNonPlannableEmployees`.

--- a/openspec/changes/add-weekend-visibility-toggle/proposal.md
+++ b/openspec/changes/add-weekend-visibility-toggle/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The planning view currently shows only the work week (Monday to Friday), with no way to plan or review assignments that fall on Saturday or Sunday.
+Some teams occasionally work weekends and need to see those days, while most prefer an uncluttered Monday to Friday view.
+
+## What Changes
+
+- Add a display toggle "Wochenende anzeigen" in the settings dialog under "Anzeige".
+- When the toggle is off (default), the planning view shows Monday to Friday (5 columns), matching today's behavior.
+- When the toggle is on, the planning view shows Monday to Sunday (7 columns), adding Saturday and Sunday.
+- Persist the toggle in the local store as part of the existing display settings so the choice survives restarts.
+
+## Capabilities
+
+### New Capabilities
+- `weekend-visibility`: Persisted display setting controlling whether the planning view shows Saturday and Sunday, defaulting to off.
+
+### Modified Capabilities
+<!-- No existing spec requirements are changing -->
+
+## Impact
+
+- Code: `getWeekDays` (week-day generation) becomes weekend-aware, the planning page reads the setting, and the settings dialog gains a toggle.
+- Storage: New `showWeekend` field on the existing `DisplaySettings` in the local store (Rust + generated TypeScript types).
+- Dependencies: Builds on the existing display-settings persistence used by `hideNonPlannableEmployees`.

--- a/openspec/changes/add-weekend-visibility-toggle/specs/weekend-visibility/spec.md
+++ b/openspec/changes/add-weekend-visibility-toggle/specs/weekend-visibility/spec.md
@@ -30,7 +30,7 @@ The system SHALL render Monday to Friday when weekend visibility is off and Mond
 - **AND** Saturday and Sunday appear after Friday
 
 ### Requirement: Toggle in settings dialog
-The system SHALL expose the weekend visibility setting as a toggle in the settings dialog under the "Anzeige" section, labelled in German.
+The system SHALL expose the weekend visibility setting as a toggle in the settings dialog under the "Anzeige" section, labelled "Wochenende anzeigen".
 
 #### Scenario: Turning the toggle on
 - **GIVEN** the settings dialog is open with the weekend toggle off

--- a/openspec/changes/add-weekend-visibility-toggle/specs/weekend-visibility/spec.md
+++ b/openspec/changes/add-weekend-visibility-toggle/specs/weekend-visibility/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Weekend visibility setting
+The system SHALL provide a persisted display setting that controls whether the planning view includes Saturday and Sunday.
+The setting SHALL default to off (weekend hidden) and SHALL be stored alongside the other display settings in the local store.
+
+#### Scenario: Default value when unset
+- **GIVEN** a local store with no explicit weekend visibility value
+- **WHEN** the planning view loads the display settings
+- **THEN** the weekend visibility setting resolves to off
+
+#### Scenario: Persisted across restarts
+- **GIVEN** the user has turned the weekend visibility setting on
+- **WHEN** the application is restarted and the display settings are loaded
+- **THEN** the weekend visibility setting is on
+
+### Requirement: Planning view respects weekend visibility
+The system SHALL render Monday to Friday when weekend visibility is off and Monday to Sunday when weekend visibility is on.
+
+#### Scenario: Weekend hidden
+- **GIVEN** the weekend visibility setting is off
+- **WHEN** the planning view renders a week
+- **THEN** exactly five day columns are shown, from Monday to Friday
+- **AND** Saturday and Sunday are not shown
+
+#### Scenario: Weekend shown
+- **GIVEN** the weekend visibility setting is on
+- **WHEN** the planning view renders a week
+- **THEN** seven day columns are shown, from Monday to Sunday
+- **AND** Saturday and Sunday appear after Friday
+
+### Requirement: Toggle in settings dialog
+The system SHALL expose the weekend visibility setting as a toggle in the settings dialog under the "Anzeige" section, labelled in German.
+
+#### Scenario: Turning the toggle on
+- **GIVEN** the settings dialog is open with the weekend toggle off
+- **WHEN** the user enables the weekend toggle and saves
+- **THEN** the setting is persisted as on
+- **AND** the planning view shows Saturday and Sunday
+
+#### Scenario: Turning the toggle off
+- **GIVEN** the settings dialog is open with the weekend toggle on
+- **WHEN** the user disables the weekend toggle and saves
+- **THEN** the setting is persisted as off
+- **AND** the planning view shows only Monday to Friday

--- a/openspec/changes/add-weekend-visibility-toggle/specs/weekend-visibility/spec.md
+++ b/openspec/changes/add-weekend-visibility-toggle/specs/weekend-visibility/spec.md
@@ -34,12 +34,12 @@ The system SHALL expose the weekend visibility setting as a toggle in the settin
 
 #### Scenario: Turning the toggle on
 - **GIVEN** the settings dialog is open with the weekend toggle off
-- **WHEN** the user enables the weekend toggle and saves
+- **WHEN** the user enables the weekend toggle and saves the dialog
 - **THEN** the setting is persisted as on
-- **AND** the planning view shows Saturday and Sunday
+- **AND** once the dialog is saved the planning view refreshes and shows Saturday and Sunday
 
 #### Scenario: Turning the toggle off
 - **GIVEN** the settings dialog is open with the weekend toggle on
-- **WHEN** the user disables the weekend toggle and saves
+- **WHEN** the user disables the weekend toggle and saves the dialog
 - **THEN** the setting is persisted as off
-- **AND** the planning view shows only Monday to Friday
+- **AND** once the dialog is saved the planning view refreshes and shows only Monday to Friday

--- a/openspec/changes/add-weekend-visibility-toggle/tasks.md
+++ b/openspec/changes/add-weekend-visibility-toggle/tasks.md
@@ -1,28 +1,29 @@
 ## 1. Persist the setting (backend)
 
-- [ ] 1.1 Add `show_weekend: bool` to `DisplaySettings` in `src-tauri/src/integrations/local_store.rs` with field documentation
-- [ ] 1.2 Default `show_weekend` to `false` in the `Default` impl and ensure missing values deserialize to `false`
-- [ ] 1.3 Add/extend Rust tests covering the default value and load/save round-trip of `show_weekend`
-- [ ] 1.4 Regenerate the TypeScript bindings so `DisplaySettings` includes `showWeekend: boolean`
+- [ ] 1.1 (RED) Add Rust tests in `src-tauri/src/integrations/local_store.rs` asserting `DisplaySettings::default().show_weekend == false`, a load/save round-trip of `show_weekend`, and that a stored value missing the field deserializes to `false`
+- [ ] 1.2 (GREEN) Add `show_weekend: bool` to `DisplaySettings` with field documentation, default it to `false`, and make missing values deserialize to `false` so the tests pass
+- [ ] 1.3 Regenerate the TypeScript bindings so `DisplaySettings` includes `showWeekend: boolean`
 
-## 2. Display-settings service (frontend)
+## 2. Week-day generation
 
-- [ ] 2.1 Add `DEFAULT_SHOW_WEEKEND = false` and `loadShowWeekend` / `saveShowWeekend` helpers in `src/services/display-settings.ts`
-- [ ] 2.2 Preserve other display settings when saving `showWeekend` (merge, do not overwrite `hideNonPlannableEmployees`)
+- [ ] 2.1 (RED) Extend `src/app/util.spec.ts` with failing cases asserting `getWeekDays` returns 5 days (Mon-Fri) when `showWeekend` is false and 7 days (Mon-Sun) when true
+- [ ] 2.2 (GREEN) Update `getWeekDays` in `src/app/util.ts` to take a `showWeekend` flag and return 5 or 7 days so the tests pass
 
-## 3. Week-day generation
+## 3. Display-settings service (frontend)
 
-- [ ] 3.1 Update `getWeekDays` in `src/app/util.ts` to take a `showWeekend` flag and return 5 (Mon-Fri) or 7 (Mon-Sun) days
-- [ ] 3.2 Update `getWeekDays` callers (`src/app.tsx`, `src/app/page.tsx`) to pass the loaded setting
-- [ ] 3.3 Update `src/app/util.spec.ts` to cover both 5-day and 7-day output
+- [ ] 3.1 (RED) Add failing tests for `loadShowWeekend` (defaults to false when unset) and `saveShowWeekend` (persists the value while preserving `hideNonPlannableEmployees`)
+- [ ] 3.2 (GREEN) Add `DEFAULT_SHOW_WEEKEND = false` and `loadShowWeekend` / `saveShowWeekend` helpers in `src/services/display-settings.ts`, merging rather than overwriting other display settings
 
 ## 4. Settings dialog toggle
 
-- [ ] 4.1 Load the current `showWeekend` value into the settings dialog state
-- [ ] 4.2 Add a "Wochenende anzeigen" toggle with a short German description under the "Anzeige" section
-- [ ] 4.3 Save the value and trigger a planning-view refresh on change
+- [ ] 4.1 (RED) Add a failing test that the settings dialog renders a "Wochenende anzeigen" toggle reflecting the loaded value and persists the change on save
+- [ ] 4.2 (GREEN) Load `showWeekend` into the dialog state, add the German-labelled toggle with a short description under the "Anzeige" section, and save plus trigger a planning-view refresh on change
 
-## 5. Verification
+## 5. Planning view wiring
 
-- [ ] 5.1 Verify the planning view shows 5 columns by default and 7 when enabled
-- [ ] 5.2 Run `bun lint`, `bun test`, and `cargo test`
+- [ ] 5.1 (RED) Add a failing test (e.g. in `src/app/page.spec.tsx`) that the planning view renders 5 day columns by default and 7 when `showWeekend` is on
+- [ ] 5.2 (GREEN) Pass the loaded `showWeekend` setting into `getWeekDays` from `src/app.tsx` / `src/app/page.tsx` so the tests pass
+
+## 6. Verification
+
+- [ ] 6.1 Run `bun lint`, `bun test`, and `cargo test` and confirm all are green

--- a/openspec/changes/add-weekend-visibility-toggle/tasks.md
+++ b/openspec/changes/add-weekend-visibility-toggle/tasks.md
@@ -1,0 +1,28 @@
+## 1. Persist the setting (backend)
+
+- [ ] 1.1 Add `show_weekend: bool` to `DisplaySettings` in `src-tauri/src/integrations/local_store.rs` with field documentation
+- [ ] 1.2 Default `show_weekend` to `false` in the `Default` impl and ensure missing values deserialize to `false`
+- [ ] 1.3 Add/extend Rust tests covering the default value and load/save round-trip of `show_weekend`
+- [ ] 1.4 Regenerate the TypeScript bindings so `DisplaySettings` includes `showWeekend: boolean`
+
+## 2. Display-settings service (frontend)
+
+- [ ] 2.1 Add `DEFAULT_SHOW_WEEKEND = false` and `loadShowWeekend` / `saveShowWeekend` helpers in `src/services/display-settings.ts`
+- [ ] 2.2 Preserve other display settings when saving `showWeekend` (merge, do not overwrite `hideNonPlannableEmployees`)
+
+## 3. Week-day generation
+
+- [ ] 3.1 Update `getWeekDays` in `src/app/util.ts` to take a `showWeekend` flag and return 5 (Mon-Fri) or 7 (Mon-Sun) days
+- [ ] 3.2 Update `getWeekDays` callers (`src/app.tsx`, `src/app/page.tsx`) to pass the loaded setting
+- [ ] 3.3 Update `src/app/util.spec.ts` to cover both 5-day and 7-day output
+
+## 4. Settings dialog toggle
+
+- [ ] 4.1 Load the current `showWeekend` value into the settings dialog state
+- [ ] 4.2 Add a "Wochenende anzeigen" toggle with a short German description under the "Anzeige" section
+- [ ] 4.3 Save the value and trigger a planning-view refresh on change
+
+## 5. Verification
+
+- [ ] 5.1 Verify the planning view shows 5 columns by default and 7 when enabled
+- [ ] 5.2 Run `bun lint`, `bun test`, and `cargo test`

--- a/openspec/changes/add-weekend-visibility-toggle/tasks.md
+++ b/openspec/changes/add-weekend-visibility-toggle/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Persist the setting (backend)
 
 - [ ] 1.1 (RED) Add Rust tests in `src-tauri/src/integrations/local_store.rs` asserting `DisplaySettings::default().show_weekend == false`, a load/save round-trip of `show_weekend`, and that a stored value missing the field deserializes to `false`
-- [ ] 1.2 (GREEN) Add `show_weekend: bool` to `DisplaySettings` with field documentation, default it to `false`, and make missing values deserialize to `false` so the tests pass
+- [ ] 1.2 (GREEN) Add `show_weekend: bool` to `DisplaySettings` with field documentation, set it to `false` in the existing manual `impl Default` block (do not switch to `#[derive(Default)]`, which would reset `hide_non_plannable_employees` to `false`), and make missing values deserialize to `false` so the tests pass
 - [ ] 1.3 Regenerate the TypeScript bindings so `DisplaySettings` includes `showWeekend: boolean`
 
 ## 2. Week-day generation
@@ -11,8 +11,10 @@
 
 ## 3. Display-settings service (frontend)
 
-- [ ] 3.1 (RED) Add failing tests for `loadShowWeekend` (defaults to false when unset) and `saveShowWeekend` (persists the value while preserving `hideNonPlannableEmployees`)
-- [ ] 3.2 (GREEN) Add `DEFAULT_SHOW_WEEKEND = false` and `loadShowWeekend` / `saveShowWeekend` helpers in `src/services/display-settings.ts`, merging rather than overwriting other display settings
+- [ ] 3.1 (RED) Add a failing test proving the existing `saveHideNonPlannableEmployees` drops `showWeekend`: save `showWeekend = true`, then call `saveHideNonPlannableEmployees(false)`, and assert the reloaded store still has `showWeekend === true`
+- [ ] 3.2 (GREEN) Fix `saveHideNonPlannableEmployees` to merge into the existing `displaySettings` instead of overwriting the whole object, so it no longer zeroes out `showWeekend`
+- [ ] 3.3 (RED) Add failing tests for `loadShowWeekend` (defaults to false when unset) and `saveShowWeekend` (persists the value while preserving `hideNonPlannableEmployees`)
+- [ ] 3.4 (GREEN) Add `DEFAULT_SHOW_WEEKEND = false` and `loadShowWeekend` / `saveShowWeekend` helpers in `src/services/display-settings.ts`, merging into the existing `displaySettings` rather than overwriting other fields
 
 ## 4. Settings dialog toggle
 

--- a/openspec/changes/add-weekend-visibility-toggle/tasks.md
+++ b/openspec/changes/add-weekend-visibility-toggle/tasks.md
@@ -1,13 +1,13 @@
 ## 1. Persist the setting (backend)
 
 - [ ] 1.1 (RED) Add Rust tests in `src-tauri/src/integrations/local_store.rs` asserting `DisplaySettings::default().show_weekend == false`, a load/save round-trip of `show_weekend`, and that a stored value missing the field deserializes to `false`
-- [ ] 1.2 (GREEN) Add `show_weekend: bool` to `DisplaySettings` with field documentation, set it to `false` in the existing manual `impl Default` block (do not switch to `#[derive(Default)]`, which would reset `hide_non_plannable_employees` to `false`), and make missing values deserialize to `false` so the tests pass
-- [ ] 1.3 Regenerate the TypeScript bindings so `DisplaySettings` includes `showWeekend: boolean`
+- [ ] 1.2 (GREEN) Add `show_weekend: bool` to `DisplaySettings` with field documentation and `#[serde(default)]` on the field (so a stored value written before this field existed deserializes to `false`; the struct-level default does not fill individual missing fields), and set it to `false` in the existing manual `impl Default` block (do not switch to `#[derive(Default)]`, which would reset `hide_non_plannable_employees` to `false`) so the tests pass
+- [ ] 1.3 (infrastructure, non-TDD) Regenerate the TypeScript bindings so `DisplaySettings` includes `showWeekend: boolean`; this is codegen output, exercised by the frontend service tests in section 3 rather than a dedicated test
 
 ## 2. Week-day generation
 
 - [ ] 2.1 (RED) Extend `src/app/util.spec.ts` with failing cases asserting `getWeekDays` returns 5 days (Mon-Fri) when `showWeekend` is false and 7 days (Mon-Sun) when true
-- [ ] 2.2 (GREEN) Update `getWeekDays` in `src/app/util.ts` to take a `showWeekend` flag and return 5 or 7 days so the tests pass
+- [ ] 2.2 (GREEN) Update `getWeekDays` in `src/app/util.ts` to take an optional `showWeekend = false` flag and return 5 or 7 days so the tests pass; the default keeps existing callers compiling and behaving as before until they are updated in task 5.2, avoiding a `bun test` breakage window
 
 ## 3. Display-settings service (frontend)
 
@@ -18,8 +18,8 @@
 
 ## 4. Settings dialog toggle
 
-- [ ] 4.1 (RED) Add a failing test that the settings dialog renders a "Wochenende anzeigen" toggle reflecting the loaded value and persists the change on save
-- [ ] 4.2 (GREEN) Load `showWeekend` into the dialog state, add the German-labelled toggle with a short description under the "Anzeige" section, and save plus trigger a planning-view refresh on change
+- [ ] 4.1 (RED) Add a failing test that the settings dialog renders a "Wochenende anzeigen" toggle reflecting the loaded value and, on save, persists the change and triggers a planning-view refresh
+- [ ] 4.2 (GREEN) Load `showWeekend` into the dialog state, add the German-labelled toggle with a short description under the "Anzeige" section, and on save persist the value and trigger the planning-view refresh (matching the existing `hideNonPlannableEmployees` save-then-reload flow)
 
 ## 5. Planning view wiring
 

--- a/openspec/changes/enable-agent-testing/.openspec.yaml
+++ b/openspec/changes/enable-agent-testing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/enable-agent-testing/design.md
+++ b/openspec/changes/enable-agent-testing/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The app is a Tauri v2 desktop application with a React/TypeScript frontend (Vite) and a Rust backend. All external API calls go through Tauri commands (`invoke`). The generated bindings live in `src/generated/tauri.ts` and wrap `@tauri-apps/api/core`'s `invoke`. Existing test suites are unit-only (Bun for TS, Cargo for Rust). There is no way to run and observe the full UI today.
+
+The Stop hook already runs `bun lint && bun test && cargo test`, so Claude gets test feedback after each session. The gap is UI-level feedback: Claude cannot start the app, navigate it, and assert visual or interactive behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Claude can run `bun test:e2e` to exercise the frontend in a real browser
+- Playwright starts and stops the Vite dev server automatically
+- `@tauri-apps/api/core` is replaced with a controllable mock at test time via a Vite alias
+- A `SessionStart` hook verifies the environment (deps installed, Rust toolchain present) so Claude gets early failure rather than silent missing-tool errors
+- Baseline smoke tests cover the app's main views so regressions are visible
+
+**Non-Goals:**
+- Testing the Rust backend through Playwright (Cargo tests cover that)
+- Running the full Tauri desktop shell in tests (unnecessary complexity, Vite-only is sufficient for UI tests)
+- Visual regression / screenshot diffing (out of scope for now)
+- CI integration (purely local agent tooling)
+
+## Decisions
+
+### Playwright over Cypress
+Playwright has first-class Vite integration via `webServer`, native TypeScript support without extra setup, and runs fully headless. Cypress requires a separate server process and has historically had flakier Vite/ESM support.
+
+### Tauri mock via Vite alias, not `vi.mock`
+At build time (Playwright uses the running Vite server, not Vitest), the cleanest intercept point is a Vite `resolve.alias` in a dedicated Playwright-specific Vite config. This replaces `@tauri-apps/api/core` with `src/test/tauri-mock.ts`, which exports a jest-spy-compatible `invoke` function. Tests can control return values per command name.
+
+Alternative considered: patching `window.__TAURI_INTERNALS` at runtime via Playwright's `page.addInitScript`. This works but is less type-safe and harder to reset between tests.
+
+### Separate `vite.playwright.config.ts`
+Playwright needs to start Vite with the mock alias active, but the normal `vite.config.ts` must stay unchanged so `bun dev` and production builds are unaffected. A thin override config extends the base config and adds the alias.
+
+### SessionStart hook (shell command)
+The hook runs a fast environment check script (`scripts/check-dev-env.ts`) that verifies `bun`, `cargo`, and Playwright browser binaries are present. It prints a clear warning if anything is missing. This is fire-and-forget (non-blocking) to avoid slowing session startup.
+
+## Risks / Trade-offs
+
+- **Tauri invoke mock drift**: As `src/generated/tauri.ts` grows, tests may call commands that have no mock handler, silently returning `undefined`. Mitigation: the mock throws by default for unregistered commands, requiring tests to explicitly stub each call they depend on.
+- **Playwright browser download**: First run downloads ~100 MB of browser binaries. Mitigation: documented in README; `scripts/check-dev-env.ts` warns if not installed.
+- **Vite port conflicts**: Playwright's `webServer` uses port 5173 by default. Mitigation: configure a dedicated port (e.g. 5174) in `vite.playwright.config.ts` so it does not clash with `bun dev`.
+- **Smoke test brittleness**: UI-level selectors break on refactors. Mitigation: use `data-testid` attributes on key elements; avoid CSS class selectors.

--- a/openspec/changes/enable-agent-testing/design.md
+++ b/openspec/changes/enable-agent-testing/design.md
@@ -1,8 +1,13 @@
 ## Context
 
-The app is a Tauri v2 desktop application with a React/TypeScript frontend (Vite) and a Rust backend. All external API calls go through Tauri commands (`invoke`). The generated bindings live in `src/generated/tauri.ts` and wrap `@tauri-apps/api/core`'s `invoke`. Existing test suites are unit-only (Bun for TS, Cargo for Rust). There is no way to run and observe the full UI today.
+The app is a Tauri v2 desktop application with a React/TypeScript frontend (Vite) and a Rust backend.
+All external API calls go through Tauri commands (`invoke`).
+The generated bindings live in `src/generated/tauri.ts` and wrap `@tauri-apps/api/core`'s `invoke`.
+Existing test suites are unit-only (Bun for TS, Cargo for Rust).
+There is no way to run and observe the full UI today.
 
-The Stop hook already runs `bun lint && bun test && cargo test`, so Claude gets test feedback after each session. The gap is UI-level feedback: Claude cannot start the app, navigate it, and assert visual or interactive behavior.
+The Stop hook already runs `bun lint && bun test && cargo test`, so Claude gets test feedback after each session.
+The gap is UI-level feedback: Claude cannot start the app, navigate it, and assert visual or interactive behavior.
 
 ## Goals / Non-Goals
 
@@ -22,22 +27,42 @@ The Stop hook already runs `bun lint && bun test && cargo test`, so Claude gets 
 ## Decisions
 
 ### Playwright over Cypress
-Playwright has first-class Vite integration via `webServer`, native TypeScript support without extra setup, and runs fully headless. Cypress requires a separate server process and has historically had flakier Vite/ESM support.
+Playwright has first-class Vite integration via `webServer`, native TypeScript support without extra setup, and runs fully headless.
+Cypress requires a separate server process and has historically had flakier Vite/ESM support.
 
 ### Tauri mock via Vite alias, not `vi.mock`
-At build time (Playwright uses the running Vite server, not Vitest), the cleanest intercept point is a Vite `resolve.alias` in a dedicated Playwright-specific Vite config. This replaces `@tauri-apps/api/core` with `src/test/tauri-mock.ts`, which exports a jest-spy-compatible `invoke` function. Tests can control return values per command name.
+At build time (Playwright uses the running Vite server, not Vitest), the cleanest intercept point is a Vite `resolve.alias` in a dedicated Playwright-specific Vite config.
+This replaces `@tauri-apps/api/core` with `src/test/tauri-mock.ts`, which exports an `invoke` function matching the real signature.
+Tests control return values per command name.
 
-Alternative considered: patching `window.__TAURI_INTERNALS` at runtime via Playwright's `page.addInitScript`. This works but is less type-safe and harder to reset between tests.
+Alternative considered: patching `window.__TAURI_INTERNALS` at runtime via Playwright's `page.addInitScript`.
+This works but is less type-safe and harder to reset between tests.
+
+### Mock registration must happen before navigation
+The frontend calls `invoke` during initial render, so stubs registered with `page.evaluate` after `page.goto` can land too late and miss those early calls.
+Tests SHALL register stubs with `page.addInitScript` so the registration runs before any application code on every navigation.
+The mock exposes its registry through a stable global (`window.__tauriMock`) that the init script populates.
+
+### Per-test mock reset
+Because the Vite server process and its module graph are shared across tests, mock handler state can bleed between tests.
+The mock SHALL expose a `reset()` that clears all registered handlers, and the Playwright setup SHALL call it in `beforeEach` (via an `addInitScript` that resets then registers, so each test starts from an empty registry).
 
 ### Separate `vite.playwright.config.ts`
-Playwright needs to start Vite with the mock alias active, but the normal `vite.config.ts` must stay unchanged so `bun dev` and production builds are unaffected. A thin override config extends the base config and adds the alias.
+Playwright needs to start Vite with the mock alias active, but the normal `vite.config.ts` must stay unchanged so `bun dev` and production builds are unaffected.
+A thin override config extends the base config and adds the alias.
 
-### SessionStart hook (shell command)
-The hook runs a fast environment check script (`scripts/check-dev-env.ts`) that verifies `bun`, `cargo`, and Playwright browser binaries are present. It prints a clear warning if anything is missing. This is fire-and-forget (non-blocking) to avoid slowing session startup.
+### SessionStart hook (shell script)
+The hook runs a POSIX shell script (`scripts/check-dev-env.sh`) invoked directly by the shell, not through `bun`.
+Running it through `bun run` would make it unable to report a missing `bun`, because the interpreter itself would be absent.
+The script checks for `bun`, `cargo`, and the Playwright browser binaries on `PATH`, prints a clear non-blocking warning for anything missing, and always exits 0 to avoid slowing or blocking session startup.
 
 ## Risks / Trade-offs
 
-- **Tauri invoke mock drift**: As `src/generated/tauri.ts` grows, tests may call commands that have no mock handler, silently returning `undefined`. Mitigation: the mock throws by default for unregistered commands, requiring tests to explicitly stub each call they depend on.
-- **Playwright browser download**: First run downloads ~100 MB of browser binaries. Mitigation: documented in README; `scripts/check-dev-env.ts` warns if not installed.
-- **Vite port conflicts**: Playwright's `webServer` uses port 5173 by default. Mitigation: configure a dedicated port (e.g. 5174) in `vite.playwright.config.ts` so it does not clash with `bun dev`.
-- **Smoke test brittleness**: UI-level selectors break on refactors. Mitigation: use `data-testid` attributes on key elements; avoid CSS class selectors.
+- **Tauri invoke mock drift**: as `src/generated/tauri.ts` grows, tests may call commands that have no mock handler.
+  - **Mitigation**: the mock throws by default for unregistered commands, requiring tests to explicitly stub each call they depend on.
+- **Playwright browser download**: first run downloads roughly 100 MB of browser binaries.
+  - **Mitigation**: documented in README; `scripts/check-dev-env.sh` warns if not installed.
+- **Vite port conflicts**: Playwright's `webServer` uses port 5173 by default.
+  - **Mitigation**: configure a dedicated port (5174) in `vite.playwright.config.ts` so it does not clash with `bun dev`.
+- **Smoke test brittleness**: UI-level selectors break on refactors.
+  - **Mitigation**: use `data-testid` attributes on key elements and avoid CSS class selectors.

--- a/openspec/changes/enable-agent-testing/design.md
+++ b/openspec/changes/enable-agent-testing/design.md
@@ -47,6 +47,13 @@ The mock exposes its registry through a stable global (`window.__tauriMock`) tha
 Because the Vite server process and its module graph are shared across tests, mock handler state can bleed between tests.
 The mock SHALL expose a `reset()` that clears all registered handlers, and the Playwright setup SHALL call it in `beforeEach` (via an `addInitScript` that resets then registers, so each test starts from an empty registry).
 
+### Type-safe mocks against the generated bindings
+The mock data is hand-authored per test, not recorded from a real backend, so without a type boundary it can silently drift from the real shapes.
+`src/generated/tauri.ts` (produced by tauri-specta from the Rust structs and commands) is the source of truth for command argument and return types.
+The mock registry SHALL be generic over the generated `commands`, so `registerMock(name, handler)` only accepts a handler whose return value is assignable to that command's generated return type; a mismatched stub then fails `tsc` (the `bun` job) instead of passing silently.
+Reusable typed fixture builders (for example `makeLocalStore(overrides)`) SHALL define each command's expected shape in one place against the generated types, so tests compose fixtures instead of scattering object literals, and a Rust type change plus regeneration surfaces as a single compile error in the builder.
+Note the `page.addInitScript` boundary serializes the handler to a string, so the typed `registerMock` wrapper and fixtures live in Node-side test code; only the already-constructed, type-checked data crosses into the browser.
+
 ### Separate `vite.playwright.config.ts`
 Playwright needs to start Vite with the mock alias active, but the normal `vite.config.ts` must stay unchanged so `bun dev` and production builds are unaffected.
 A thin override config extends the base config and adds the alias.
@@ -58,8 +65,8 @@ The script checks for `bun`, `cargo`, and the Playwright browser binaries on `PA
 
 ## Risks / Trade-offs
 
-- **Tauri invoke mock drift**: as `src/generated/tauri.ts` grows, tests may call commands that have no mock handler.
-  - **Mitigation**: the mock throws by default for unregistered commands, requiring tests to explicitly stub each call they depend on.
+- **Tauri invoke mock drift**: as `src/generated/tauri.ts` grows, tests may call commands that have no mock handler, or stub a command with a value that no longer matches its real shape.
+  - **Mitigation**: the mock throws by default for unregistered commands (catching missing handlers at runtime), and the registry plus fixtures are typed against the generated bindings (catching shape mismatches at compile time), so both the call coverage and the data shape are guarded.
 - **Playwright browser download**: first run downloads roughly 100 MB of browser binaries.
   - **Mitigation**: captured as the one-time prerequisite step in tasks.md, and `scripts/check-dev-env.sh` warns if not installed.
 - **Vite port conflicts**: Playwright's `webServer` uses port 5173 by default.

--- a/openspec/changes/enable-agent-testing/design.md
+++ b/openspec/changes/enable-agent-testing/design.md
@@ -61,7 +61,7 @@ The script checks for `bun`, `cargo`, and the Playwright browser binaries on `PA
 - **Tauri invoke mock drift**: as `src/generated/tauri.ts` grows, tests may call commands that have no mock handler.
   - **Mitigation**: the mock throws by default for unregistered commands, requiring tests to explicitly stub each call they depend on.
 - **Playwright browser download**: first run downloads roughly 100 MB of browser binaries.
-  - **Mitigation**: documented in README; `scripts/check-dev-env.sh` warns if not installed.
+  - **Mitigation**: captured as the one-time prerequisite step in tasks.md, and `scripts/check-dev-env.sh` warns if not installed.
 - **Vite port conflicts**: Playwright's `webServer` uses port 5173 by default.
   - **Mitigation**: configure a dedicated port (5174) in `vite.playwright.config.ts` so it does not clash with `bun dev`.
 - **Smoke test brittleness**: UI-level selectors break on refactors.

--- a/openspec/changes/enable-agent-testing/proposal.md
+++ b/openspec/changes/enable-agent-testing/proposal.md
@@ -1,6 +1,7 @@
 ## Why
 
-Claude currently cannot verify UI and integration behavior by running the application, which limits code quality when using agentic engineering. Adding Playwright-based end-to-end testing against the Vite frontend — with mocked Tauri backend calls — gives Claude a reliable way to start the app, interact with it, and assert correctness before declaring tasks complete.
+Claude currently cannot verify UI and integration behavior by running the application, which limits code quality when using agentic engineering.
+Adding Playwright-based end-to-end testing against the Vite frontend, with mocked Tauri backend calls, gives Claude a reliable way to start the app, interact with it, and assert correctness before declaring tasks complete.
 
 ## What Changes
 
@@ -17,8 +18,7 @@ Claude currently cannot verify UI and integration behavior by running the applic
 - `e2e-testing`: Playwright setup with Vite dev server and mocked Tauri backend, plus a `test:e2e` script and baseline smoke tests, enabling Claude to run automated UI tests
 
 ### Modified Capabilities
-
-- `http-recording`: No requirement changes — implementation detail only (Playwright test runner is separate from VCR tests)
+<!-- No existing spec requirements are changing -->
 
 ## Impact
 

--- a/openspec/changes/enable-agent-testing/proposal.md
+++ b/openspec/changes/enable-agent-testing/proposal.md
@@ -24,5 +24,5 @@ Adding Playwright-based end-to-end testing against the Vite frontend, with mocke
 
 - `package.json`: new `test:e2e` script, new Playwright devDependencies
 - `.claude/settings.json`: new `SessionStart` hook
-- New files: `playwright.config.ts`, `src/test/tauri-mock.ts`, `tests/e2e/` directory with baseline smoke tests
+- New files: `playwright.config.ts`, `vite.playwright.config.ts`, `src/test/tauri-mock.ts`, `scripts/check-dev-env.sh`, `tests/e2e/` directory with baseline smoke tests
 - No changes to Rust backend or existing Bun/Cargo test suites

--- a/openspec/changes/enable-agent-testing/proposal.md
+++ b/openspec/changes/enable-agent-testing/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Claude currently cannot verify UI and integration behavior by running the application, which limits code quality when using agentic engineering. Adding Playwright-based end-to-end testing against the Vite frontend — with mocked Tauri backend calls — gives Claude a reliable way to start the app, interact with it, and assert correctness before declaring tasks complete.
+
+## What Changes
+
+- Add Playwright as an E2E testing framework targeting the Vite dev server
+- Add a Tauri API mock layer so `invoke()` calls work in a browser test context
+- Add `test:e2e` script to `package.json`
+- Add a `SessionStart` hook so Claude automatically verifies the dev environment is ready at the start of each session
+- Provide a small set of smoke tests covering the app's main views as a baseline
+
+## Capabilities
+
+### New Capabilities
+
+- `e2e-testing`: Playwright setup with Vite dev server and mocked Tauri backend, plus a `test:e2e` script and baseline smoke tests, enabling Claude to run automated UI tests
+
+### Modified Capabilities
+
+- `http-recording`: No requirement changes — implementation detail only (Playwright test runner is separate from VCR tests)
+
+## Impact
+
+- `package.json`: new `test:e2e` script, new Playwright devDependencies
+- `.claude/settings.json`: new `SessionStart` hook
+- New files: `playwright.config.ts`, `src/test/tauri-mock.ts`, `tests/e2e/` directory with baseline smoke tests
+- No changes to Rust backend or existing Bun/Cargo test suites

--- a/openspec/changes/enable-agent-testing/specs/e2e-testing/spec.md
+++ b/openspec/changes/enable-agent-testing/specs/e2e-testing/spec.md
@@ -29,6 +29,19 @@ Tests SHALL register stubs before navigation (via `page.addInitScript`) so `invo
 - **WHEN** the frontend calls `invoke` for a command that no test stub covers
 - **THEN** the mock throws a descriptive error identifying the unregistered command name
 
+### Requirement: Mock stubs are type-checked against the generated bindings
+The system SHALL type the mock registry and its fixtures against the generated command bindings (`src/generated/tauri.ts`), which are the source of truth derived from the Rust backend.
+Registering a stub for a command SHALL require a return value assignable to that command's generated return type, so a stub that does not match the real shape fails type checking (`bun test` / `tsc`) rather than passing silently.
+Reusable typed fixture builders SHALL be provided for the commands the tests depend on, so the expected shape is defined in one place and drift surfaces as a single compile error when the Rust types change and the bindings are regenerated.
+
+#### Scenario: Mismatched stub fails type checking
+- **WHEN** a test registers a stub for `"load_local_store"` whose value is missing a field required by the generated `LocalStore` type
+- **THEN** type checking fails and the test suite does not run until the stub is corrected
+
+#### Scenario: Drift surfaces at one place after regeneration
+- **WHEN** a Rust command type gains a required field and the bindings are regenerated
+- **THEN** the corresponding typed fixture builder fails type checking, pointing to the single place that must be updated
+
 ### Requirement: Smoke tests cover the main application views
 The system SHALL include at least one Playwright smoke test per top-level view of the application.
 Each smoke test SHALL verify that the view renders without JavaScript errors.

--- a/openspec/changes/enable-agent-testing/specs/e2e-testing/spec.md
+++ b/openspec/changes/enable-agent-testing/specs/e2e-testing/spec.md
@@ -1,7 +1,8 @@
 ## ADDED Requirements
 
 ### Requirement: E2E test suite runs against the Vite dev server
-The system SHALL provide a `bun test:e2e` command that starts a dedicated Vite dev server (port 5174) and runs Playwright tests against it. The command SHALL exit with a non-zero code if any test fails.
+The system SHALL provide a `bun test:e2e` command that starts a dedicated Vite dev server (port 5174) and runs Playwright tests against it.
+The command SHALL exit with a non-zero code if any test fails.
 
 #### Scenario: Successful test run
 - **WHEN** `bun test:e2e` is executed in the project root
@@ -12,25 +13,33 @@ The system SHALL provide a `bun test:e2e` command that starts a dedicated Vite d
 - **THEN** the command exits with a non-zero code and prints the failing test name and assertion
 
 ### Requirement: Tauri backend calls are mocked in E2E tests
-The system SHALL replace `@tauri-apps/api/core` with a test mock (`src/test/tauri-mock.ts`) when running under Playwright, via a Vite alias in `vite.playwright.config.ts`. The mock SHALL throw an error for any `invoke` call that has not been explicitly registered in a test.
+The system SHALL replace `@tauri-apps/api/core` with a test mock (`src/test/tauri-mock.ts`) when running under Playwright, via a Vite alias in `vite.playwright.config.ts`.
+The mock SHALL throw an error for any `invoke` call that has not been explicitly registered in a test.
+Tests SHALL register stubs before navigation (via `page.addInitScript`) so `invoke` calls made during initial render are covered, and the registry SHALL be reset before each test so handlers do not bleed between tests.
 
 #### Scenario: Registered invoke call returns stub value
-- **WHEN** a Playwright test registers a mock for command `"load_local_store"` returning `{ employees: [] }`
-- **THEN** any `invoke("load_local_store")` call from the frontend returns that value
+- **WHEN** a Playwright test registers a mock for command `"load_local_store"` returning `{ employees: [] }` before navigating
+- **THEN** any `invoke("load_local_store")` call from the frontend, including calls during initial render, returns that value
+
+#### Scenario: Handlers reset between tests
+- **WHEN** a new test starts after a previous test registered handlers
+- **THEN** the mock registry is empty until the new test registers its own handlers
 
 #### Scenario: Unregistered invoke call throws
 - **WHEN** the frontend calls `invoke` for a command that no test stub covers
 - **THEN** the mock throws a descriptive error identifying the unregistered command name
 
 ### Requirement: Smoke tests cover the main application views
-The system SHALL include at least one Playwright smoke test per top-level view of the application. Each smoke test SHALL verify that the view renders without JavaScript errors.
+The system SHALL include at least one Playwright smoke test per top-level view of the application.
+Each smoke test SHALL verify that the view renders without JavaScript errors.
 
 #### Scenario: Planning view loads
 - **WHEN** Playwright navigates to `/`
 - **THEN** the page title or a prominent heading is visible and no unhandled JavaScript errors occur
 
 ### Requirement: SessionStart hook checks the development environment
-The system SHALL execute a fast environment check (`scripts/check-dev-env.ts`) at the start of each Claude Code session. The check SHALL warn (non-blocking) if any of the following are missing: `bun`, `cargo`, Playwright browser binaries.
+The system SHALL execute a fast environment check at the start of each Claude Code session via a POSIX shell script (`scripts/check-dev-env.sh`) run directly by the shell, not through `bun`, so that a missing `bun` can still be reported.
+The check SHALL warn (non-blocking) if any of the following are missing: `bun`, `cargo`, Playwright browser binaries.
 
 #### Scenario: All tools present
 - **WHEN** `bun`, `cargo`, and Playwright browser binaries are installed
@@ -43,3 +52,7 @@ The system SHALL execute a fast environment check (`scripts/check-dev-env.ts`) a
 #### Scenario: Missing cargo
 - **WHEN** `cargo` is not found on PATH
 - **THEN** the hook prints a warning message and exits 0 (non-blocking)
+
+#### Scenario: Missing bun
+- **WHEN** `bun` is not found on PATH
+- **THEN** the shell script still runs and prints a warning identifying `bun` as missing, and exits 0 (non-blocking)

--- a/openspec/changes/enable-agent-testing/specs/e2e-testing/spec.md
+++ b/openspec/changes/enable-agent-testing/specs/e2e-testing/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: E2E test suite runs against the Vite dev server
+The system SHALL provide a `bun test:e2e` command that starts a dedicated Vite dev server (port 5174) and runs Playwright tests against it. The command SHALL exit with a non-zero code if any test fails.
+
+#### Scenario: Successful test run
+- **WHEN** `bun test:e2e` is executed in the project root
+- **THEN** Playwright starts the Vite dev server, runs all tests in `tests/e2e/`, and exits 0 on success
+
+#### Scenario: Test failure is surfaced
+- **WHEN** a Playwright test assertion fails
+- **THEN** the command exits with a non-zero code and prints the failing test name and assertion
+
+### Requirement: Tauri backend calls are mocked in E2E tests
+The system SHALL replace `@tauri-apps/api/core` with a test mock (`src/test/tauri-mock.ts`) when running under Playwright, via a Vite alias in `vite.playwright.config.ts`. The mock SHALL throw an error for any `invoke` call that has not been explicitly registered in a test.
+
+#### Scenario: Registered invoke call returns stub value
+- **WHEN** a Playwright test registers a mock for command `"load_local_store"` returning `{ employees: [] }`
+- **THEN** any `invoke("load_local_store")` call from the frontend returns that value
+
+#### Scenario: Unregistered invoke call throws
+- **WHEN** the frontend calls `invoke` for a command that no test stub covers
+- **THEN** the mock throws a descriptive error identifying the unregistered command name
+
+### Requirement: Smoke tests cover the main application views
+The system SHALL include at least one Playwright smoke test per top-level view of the application. Each smoke test SHALL verify that the view renders without JavaScript errors.
+
+#### Scenario: Planning view loads
+- **WHEN** Playwright navigates to `/`
+- **THEN** the page title or a prominent heading is visible and no unhandled JavaScript errors occur
+
+### Requirement: SessionStart hook checks the development environment
+The system SHALL execute a fast environment check (`scripts/check-dev-env.ts`) at the start of each Claude Code session. The check SHALL warn (non-blocking) if any of the following are missing: `bun`, `cargo`, Playwright browser binaries.
+
+#### Scenario: All tools present
+- **WHEN** `bun`, `cargo`, and Playwright browser binaries are installed
+- **THEN** the hook completes silently with exit code 0
+
+#### Scenario: Missing Playwright browsers
+- **WHEN** Playwright browser binaries have not been installed
+- **THEN** the hook prints a warning message instructing the user to run `bunx playwright install` and exits 0 (non-blocking)
+
+#### Scenario: Missing cargo
+- **WHEN** `cargo` is not found on PATH
+- **THEN** the hook prints a warning message and exits 0 (non-blocking)

--- a/openspec/changes/enable-agent-testing/specs/e2e-testing/spec.md
+++ b/openspec/changes/enable-agent-testing/specs/e2e-testing/spec.md
@@ -18,7 +18,7 @@ The mock SHALL throw an error for any `invoke` call that has not been explicitly
 Tests SHALL register stubs before navigation (via `page.addInitScript`) so `invoke` calls made during initial render are covered, and the registry SHALL be reset before each test so handlers do not bleed between tests.
 
 #### Scenario: Registered invoke call returns stub value
-- **WHEN** a Playwright test registers a mock for command `"load_local_store"` returning `{ employees: [] }` before navigating
+- **WHEN** a Playwright test registers a mock for command `"load_local_store"` returning a `LocalStore`-shaped value (for example `{ employeeSettings: [] }`, illustrative and partial) before navigating
 - **THEN** any `invoke("load_local_store")` call from the frontend, including calls during initial render, returns that value
 
 #### Scenario: Handlers reset between tests

--- a/openspec/changes/enable-agent-testing/tasks.md
+++ b/openspec/changes/enable-agent-testing/tasks.md
@@ -1,17 +1,23 @@
+## 0. Prerequisites
+
+- One-time setup (not a repeatable implementation step): run `bunx playwright install chromium` to download the browser binaries. `scripts/check-dev-env.sh` (task 4) warns when this is missing.
+
 ## 1. Playwright Dependencies & Configuration
 
 - [ ] 1.1 Add `@playwright/test` as a dev dependency (`bun add -d @playwright/test`)
 - [ ] 1.2 Create `vite.playwright.config.ts` that extends `vite.config.ts` and adds a `resolve.alias` mapping `@tauri-apps/api/core` to `src/test/tauri-mock.ts` and sets port to 5174
 - [ ] 1.3 Create `playwright.config.ts` with `webServer` pointing to `vite.playwright.config.ts`, test directory `tests/e2e/`, and headless browser configuration
 - [ ] 1.4 Add `"test:e2e": "playwright test"` script to `package.json`
-- [ ] 1.5 Run `bunx playwright install chromium` to download browser binaries and verify `bun test:e2e` can start without errors
+- [ ] 1.5 Verify `bun test:e2e` can start the Vite dev server and discover tests without errors (browser binaries from the prerequisite step must be installed)
 
 ## 2. Tauri Mock Layer
 
 - [ ] 2.1 Create `src/test/tauri-mock.ts` that exports an `invoke` function matching the `@tauri-apps/api/core` interface
-- [ ] 2.2 The mock SHALL maintain a per-test handler registry (`registerMock(commandName, handler)`) exposed on `window.__tauriMock` so Playwright tests can register stubs via `page.evaluate`
-- [ ] 2.3 The mock SHALL throw a descriptive error (`Unregistered Tauri command: "<name>"`) for any `invoke` call with no registered handler
-- [ ] 2.4 Write a unit test (Bun) verifying the mock throws for unregistered commands and returns stub values for registered ones
+- [ ] 2.2 Maintain a handler registry exposed on `window.__tauriMock` with `registerMock(commandName, handler)` and a `reset()` that clears all handlers
+- [ ] 2.3 Register stubs via `page.addInitScript` (which runs before any app code on each navigation), not `page.evaluate` after `page.goto`, so early `invoke` calls during initial render are covered
+- [ ] 2.4 Add a Playwright `beforeEach` (an `addInitScript` that calls `reset()` before registering) so handler state never bleeds between tests sharing the Vite server process
+- [ ] 2.5 The mock SHALL throw a descriptive error (`Unregistered Tauri command: "<name>"`) for any `invoke` call with no registered handler
+- [ ] 2.6 Write a unit test (Bun) verifying the mock throws for unregistered commands, returns stub values for registered ones, and clears handlers on `reset()`
 
 ## 3. Baseline Smoke Tests
 
@@ -22,6 +28,6 @@
 
 ## 4. SessionStart Hook
 
-- [ ] 4.1 Create `scripts/check-dev-env.ts` that checks for `bun`, `cargo`, and Playwright chromium binary; prints a non-blocking warning for each missing tool
-- [ ] 4.2 Add a `SessionStart` hook entry to `.claude/settings.json` that runs `bun run scripts/check-dev-env.ts`
+- [ ] 4.1 Create a POSIX shell script `scripts/check-dev-env.sh` that checks for `bun`, `cargo`, and the Playwright chromium binary on `PATH`, prints a non-blocking warning for each missing tool, and always exits 0. A shell script is used (not a `bun`-run TS file) so it can still report a missing `bun`
+- [ ] 4.2 Add a `SessionStart` hook entry to `.claude/settings.json` that runs `sh scripts/check-dev-env.sh` directly (not through `bun`)
 - [ ] 4.3 Verify the hook runs cleanly in a new Claude Code session and reports correctly when all tools are present

--- a/openspec/changes/enable-agent-testing/tasks.md
+++ b/openspec/changes/enable-agent-testing/tasks.md
@@ -19,9 +19,16 @@
 - [ ] 2.5 Register stubs via `page.addInitScript` (which runs before any app code on each navigation), not `page.evaluate` after `page.goto`, so early `invoke` calls during initial render are covered
 - [ ] 2.6 Add a Playwright `beforeEach` (an `addInitScript` that calls `reset()` before registering) so handler state never bleeds between tests sharing the Vite server process
 
+## 2a. Type-safe mock registry and fixtures
+
+- [ ] 2a.1 (RED) Add a type-level test (for example a `tsc`-checked `*.test-d.ts` or a compile-failure assertion) proving that `registerMock("load_local_store", ...)` rejects a value not assignable to the generated `LocalStore` return type; it fails because `registerMock` is currently untyped
+- [ ] 2a.2 (GREEN) Make `registerMock` generic over the generated `commands` from `src/generated/tauri.ts`, so the handler's return type must match the selected command's generated return type, turning shape mismatches into `tsc` (`bun`) failures
+- [ ] 2a.3 (RED) Add a test for a typed fixture builder (for example `makeLocalStore(overrides)`) asserting it returns a valid `LocalStore` and applies overrides; it fails because the builder does not exist yet
+- [ ] 2a.4 (GREEN) Create reusable typed fixture builders for the commands the smoke tests depend on (`load_local_store`, `load_week_events`, `get_holidays_for_week`), typed against the generated bindings so drift surfaces in one place after regeneration
+
 ## 3. Baseline Smoke Tests
 
-- [ ] 3.1 (RED) Create `tests/e2e/smoke.spec.ts` that navigates to `/`, registers the minimal `invoke` mocks the planning view needs (at minimum: `load_local_store`, `load_week_events`, `get_holidays_for_week`), and asserts a `data-testid`-selected element is visible with no unhandled JavaScript errors; it fails because the test ids do not exist yet
+- [ ] 3.1 (RED) Create `tests/e2e/smoke.spec.ts` that navigates to `/`, registers the minimal `invoke` mocks the planning view needs using the typed fixture builders from task 2a (at minimum: `load_local_store`, `load_week_events`, `get_holidays_for_week`), and asserts a `data-testid`-selected element is visible with no unhandled JavaScript errors; it fails because the test ids do not exist yet
 - [ ] 3.2 (GREEN) Add `data-testid` attributes to key structural elements in the main view component so the smoke test can use stable selectors
 - [ ] 3.3 Run `bun test:e2e` and confirm all smoke tests pass
 

--- a/openspec/changes/enable-agent-testing/tasks.md
+++ b/openspec/changes/enable-agent-testing/tasks.md
@@ -1,0 +1,27 @@
+## 1. Playwright Dependencies & Configuration
+
+- [ ] 1.1 Add `@playwright/test` as a dev dependency (`bun add -d @playwright/test`)
+- [ ] 1.2 Create `vite.playwright.config.ts` that extends `vite.config.ts` and adds a `resolve.alias` mapping `@tauri-apps/api/core` to `src/test/tauri-mock.ts` and sets port to 5174
+- [ ] 1.3 Create `playwright.config.ts` with `webServer` pointing to `vite.playwright.config.ts`, test directory `tests/e2e/`, and headless browser configuration
+- [ ] 1.4 Add `"test:e2e": "playwright test"` script to `package.json`
+- [ ] 1.5 Run `bunx playwright install chromium` to download browser binaries and verify `bun test:e2e` can start without errors
+
+## 2. Tauri Mock Layer
+
+- [ ] 2.1 Create `src/test/tauri-mock.ts` that exports an `invoke` function matching the `@tauri-apps/api/core` interface
+- [ ] 2.2 The mock SHALL maintain a per-test handler registry (`registerMock(commandName, handler)`) exposed on `window.__tauriMock` so Playwright tests can register stubs via `page.evaluate`
+- [ ] 2.3 The mock SHALL throw a descriptive error (`Unregistered Tauri command: "<name>"`) for any `invoke` call with no registered handler
+- [ ] 2.4 Write a unit test (Bun) verifying the mock throws for unregistered commands and returns stub values for registered ones
+
+## 3. Baseline Smoke Tests
+
+- [ ] 3.1 Create `tests/e2e/smoke.spec.ts` with a test that navigates to `/` and asserts the app renders without JavaScript errors
+- [ ] 3.2 Register minimal `invoke` mocks needed for the planning view to render (at minimum: `load_local_store`, `load_week_events`, `get_holidays_for_week`)
+- [ ] 3.3 Add `data-testid` attributes to key structural elements in the main view component so smoke tests can use stable selectors
+- [ ] 3.4 Run `bun test:e2e` and confirm all smoke tests pass
+
+## 4. SessionStart Hook
+
+- [ ] 4.1 Create `scripts/check-dev-env.ts` that checks for `bun`, `cargo`, and Playwright chromium binary; prints a non-blocking warning for each missing tool
+- [ ] 4.2 Add a `SessionStart` hook entry to `.claude/settings.json` that runs `bun run scripts/check-dev-env.ts`
+- [ ] 4.3 Verify the hook runs cleanly in a new Claude Code session and reports correctly when all tools are present

--- a/openspec/changes/enable-agent-testing/tasks.md
+++ b/openspec/changes/enable-agent-testing/tasks.md
@@ -4,30 +4,30 @@
 
 ## 1. Playwright Dependencies & Configuration
 
-- [ ] 1.1 Add `@playwright/test` as a dev dependency (`bun add -d @playwright/test`)
-- [ ] 1.2 Create `vite.playwright.config.ts` that extends `vite.config.ts` and adds a `resolve.alias` mapping `@tauri-apps/api/core` to `src/test/tauri-mock.ts` and sets port to 5174
-- [ ] 1.3 Create `playwright.config.ts` with `webServer` pointing to `vite.playwright.config.ts`, test directory `tests/e2e/`, and headless browser configuration
-- [ ] 1.4 Add `"test:e2e": "playwright test"` script to `package.json`
-- [ ] 1.5 Verify `bun test:e2e` can start the Vite dev server and discover tests without errors (browser binaries from the prerequisite step must be installed)
+- [ ] 1.1 (RED) Add a minimal `tests/e2e/setup.spec.ts` that navigates to `/` and asserts the document loads; running `bun test:e2e` fails because the runner, config, and script do not exist yet
+- [ ] 1.2 (GREEN) Add `@playwright/test` as a dev dependency (`bun add -d @playwright/test`)
+- [ ] 1.3 (GREEN) Create `vite.playwright.config.ts` that extends `vite.config.ts` and adds a `resolve.alias` mapping `@tauri-apps/api/core` to `src/test/tauri-mock.ts` and sets port to 5174
+- [ ] 1.4 (GREEN) Create `playwright.config.ts` with `webServer` pointing to `vite.playwright.config.ts`, test directory `tests/e2e/`, and headless browser configuration
+- [ ] 1.5 (GREEN) Add `"test:e2e": "playwright test"` script to `package.json` so `bun test:e2e` starts the dev server and the setup test passes (browser binaries from the prerequisite step must be installed)
 
 ## 2. Tauri Mock Layer
 
-- [ ] 2.1 Create `src/test/tauri-mock.ts` that exports an `invoke` function matching the `@tauri-apps/api/core` interface
-- [ ] 2.2 Maintain a handler registry exposed on `window.__tauriMock` with `registerMock(commandName, handler)` and a `reset()` that clears all handlers
-- [ ] 2.3 Register stubs via `page.addInitScript` (which runs before any app code on each navigation), not `page.evaluate` after `page.goto`, so early `invoke` calls during initial render are covered
-- [ ] 2.4 Add a Playwright `beforeEach` (an `addInitScript` that calls `reset()` before registering) so handler state never bleeds between tests sharing the Vite server process
-- [ ] 2.5 The mock SHALL throw a descriptive error (`Unregistered Tauri command: "<name>"`) for any `invoke` call with no registered handler
-- [ ] 2.6 Write a unit test (Bun) verifying the mock throws for unregistered commands, returns stub values for registered ones, and clears handlers on `reset()`
+- [ ] 2.1 (RED) Write a unit test (Bun) for `src/test/tauri-mock.ts` asserting it throws for unregistered commands, returns stub values for registered ones, and clears handlers on `reset()`; it fails because the module does not exist yet
+- [ ] 2.2 (GREEN) Create `src/test/tauri-mock.ts` exporting an `invoke` function matching the `@tauri-apps/api/core` interface
+- [ ] 2.3 (GREEN) Maintain a handler registry exposed on `window.__tauriMock` with `registerMock(commandName, handler)` and a `reset()` that clears all handlers
+- [ ] 2.4 (GREEN) Make the mock throw a descriptive error (`Unregistered Tauri command: "<name>"`) for any `invoke` call with no registered handler, so the unit test passes
+- [ ] 2.5 Register stubs via `page.addInitScript` (which runs before any app code on each navigation), not `page.evaluate` after `page.goto`, so early `invoke` calls during initial render are covered
+- [ ] 2.6 Add a Playwright `beforeEach` (an `addInitScript` that calls `reset()` before registering) so handler state never bleeds between tests sharing the Vite server process
 
 ## 3. Baseline Smoke Tests
 
-- [ ] 3.1 Create `tests/e2e/smoke.spec.ts` with a test that navigates to `/` and asserts the app renders without JavaScript errors
-- [ ] 3.2 Register minimal `invoke` mocks needed for the planning view to render (at minimum: `load_local_store`, `load_week_events`, `get_holidays_for_week`)
-- [ ] 3.3 Add `data-testid` attributes to key structural elements in the main view component so smoke tests can use stable selectors
-- [ ] 3.4 Run `bun test:e2e` and confirm all smoke tests pass
+- [ ] 3.1 (RED) Create `tests/e2e/smoke.spec.ts` that navigates to `/`, registers the minimal `invoke` mocks the planning view needs (at minimum: `load_local_store`, `load_week_events`, `get_holidays_for_week`), and asserts a `data-testid`-selected element is visible with no unhandled JavaScript errors; it fails because the test ids do not exist yet
+- [ ] 3.2 (GREEN) Add `data-testid` attributes to key structural elements in the main view component so the smoke test can use stable selectors
+- [ ] 3.3 Run `bun test:e2e` and confirm all smoke tests pass
 
 ## 4. SessionStart Hook
 
-- [ ] 4.1 Create a POSIX shell script `scripts/check-dev-env.sh` that checks for `bun`, `cargo`, and the Playwright chromium binary on `PATH`, prints a non-blocking warning for each missing tool, and always exits 0. A shell script is used (not a `bun`-run TS file) so it can still report a missing `bun`
-- [ ] 4.2 Add a `SessionStart` hook entry to `.claude/settings.json` that runs `sh scripts/check-dev-env.sh` directly (not through `bun`)
-- [ ] 4.3 Verify the hook runs cleanly in a new Claude Code session and reports correctly when all tools are present
+- [ ] 4.1 (RED) Write a unit test (Bun) that runs `scripts/check-dev-env.sh` with a controlled `PATH` and asserts it warns for each missing tool (`bun`, `cargo`, Playwright chromium) and always exits 0; it fails because the script does not exist yet
+- [ ] 4.2 (GREEN) Create the POSIX shell script `scripts/check-dev-env.sh` that checks for `bun`, `cargo`, and the Playwright chromium binary on `PATH`, prints a non-blocking warning for each missing tool, and always exits 0. A shell script is used (not a `bun`-run TS file) so it can still report a missing `bun`
+- [ ] 4.3 Add a `SessionStart` hook entry to `.claude/settings.json` that runs `sh scripts/check-dev-env.sh` directly (not through `bun`)
+- [ ] 4.4 Verify the hook runs cleanly in a new Claude Code session and reports correctly when all tools are present


### PR DESCRIPTION
This PR adds two OpenSpec change proposals under `openspec/changes/`.
It is documentation only (proposal, design, spec, and tasks artifacts); no application code is implemented yet.

## Changes in this PR

### add-weekend-visibility-toggle
Proposes a persisted display setting that controls whether the planning view shows Saturday and Sunday, defaulting to off (weekend hidden).

- Adds a `show_weekend` field to the existing `DisplaySettings` in the local store, with `#[serde(default)]` on the field and `false` set in the manual `impl Default` block.
- Makes `getWeekDays` weekend-aware via an optional `showWeekend = false` parameter, returning 5 days (Monday to Friday) or 7 days (Monday to Sunday).
- Adds a German-labelled "Wochenende anzeigen" toggle under the settings dialog "Anzeige" section that persists and refreshes the view on save.
- Fixes an existing bug where `saveHideNonPlannableEmployees` overwrites the whole `displaySettings` object, so saving one display field no longer drops the other.

### enable-agent-testing
Proposes Playwright-based end-to-end testing against the Vite frontend with a mocked Tauri backend, so the agent can run and observe the UI.

- Replaces `@tauri-apps/api/core` with a mock via a Vite alias, registers stubs before navigation, and resets the registry per test.
- Types the mock registry and reusable fixtures against the generated bindings (`src/generated/tauri.ts`), so a stub whose shape drifts from its command fails type checking.
- Adds baseline smoke tests for the main views and a `SessionStart` hook (a POSIX shell script) that checks `bun`, `cargo`, and the Playwright browser binaries.

## Notes

- Tasks follow the project's red/green TDD convention, with failing tests preceding implementation.
- Both changes pass `openspec validate --strict` and `bun run test:docs`.
- Implementation is intended to follow via `/opsx:apply` once the proposals are approved.
