### PR TITLE
Refine BL-031 assignment modal suggestions to use client cache

### DIFF
--- a/openspec/changes/bl-031-assignment-modal-default-suggestions/design.md
+++ b/openspec/changes/bl-031-assignment-modal-default-suggestions/design.md
@@ -52,6 +52,13 @@ The assignment modal needs default suggestions to help users quickly select proj
 - Recent project comes directly from the client last-used cache
 - Sort overdue by project ID for consistent tie-breaking
 
+### Empty-state ownership (relationship to BL-032)
+**Decision**: All default-suggestion behavior lives here, plugged into BL-032's combobox empty state
+- BL-032 ships the combobox shell (input + result list + keyboard nav) with a generic empty state
+- This change supplies the empty-state content (recent + overdue) and the behavior of restoring it when the filter is cleared or Escape resets a non-empty filter
+- Keyboard navigation is BL-032's mechanism operating on the displayed list; this change only ensures suggestions feed into that same list structure so arrow/Enter work over them
+- This change therefore depends on BL-032; BL-032 does not depend on it
+
 ## Risks / Trade-offs
 
 - **Risk**: Slow query affecting modal open time

--- a/openspec/changes/bl-031-assignment-modal-default-suggestions/design.md
+++ b/openspec/changes/bl-031-assignment-modal-default-suggestions/design.md
@@ -11,8 +11,8 @@ The assignment modal needs default suggestions to help users quickly select proj
 - Handle empty states gracefully with German messages
 
 **Non-Goals:**
-- Free-text filtering behavior (covered by BL-032)
-- Persisting personal search history
+- Free-text filtering behavior (covered by BL-032, which also provides the combobox shell this change renders suggestions into)
+- Persisting personal search history across sessions (the last-used cache is in-memory and resets on restart)
 
 ## Decisions
 
@@ -23,26 +23,39 @@ The assignment modal needs default suggestions to help users quickly select proj
 - This is a new Tauri command added in this change, building on BL-022 infrastructure
 - Sort by numeric project ID ascending (same as BL-022), limit to 5
 
+### Most Recently Assigned Project Source
+**Decision**: Derive "most recently assigned" from a client-side last-used cache, not from CalDAV history
+- Assignments live as CalDAV VEVENTs loaded per week per employee; there is no cross-time assignment history query, and the iCal parser does not retain `CREATED`/`LAST-MODIFIED`
+- Instead, remember the last project the user assigned during the current session in a temporary client cache (in-memory, reset on app restart)
+- This avoids a slow multi-calendar CalDAV scan and keeps the feature deterministic for a given cache state
+- Trade-off: "recent" is session-scoped, so a freshly started session shows overdue-only suggestions until the user makes an assignment
+
 ### Suggestion Ordering
-**Decision**: Most recently assigned project first, then overdue projects
-- Query assignment history for most recent project
-- Query overdue projects via new overdue command
+**Decision**: Recent project first (if cached), then overdue projects
+- Read the most recent project from the client last-used cache
+- Query overdue projects via the new overdue command
 - Combine results, cap at 5 total suggestions
+- When the cache is empty, show up to 5 overdue projects
+
+### Deduplication
+**Decision**: A project appears at most once across the combined list
+- If the recent project is also in the overdue results, keep it only in the first (recent) position and drop it from the overdue portion
+- Dedup happens before the cap of 5 is applied, so the list holds 5 distinct projects when that many exist
 
 ### Fallback Behavior
 **Decision**: Show empty state message when no suggestions available
-- If no recent assignment AND no overdue projects
+- If the client last-used cache is empty AND no overdue projects exist
 - Show "Keine Vorschläge verfügbar" in German
 
 ### Determinism
 **Decision**: Use consistent ordering for identical states
-- Sort by assignment date descending for recent
-- Sort by project ID for overdue (consistent tie-breaking)
+- Recent project comes directly from the client last-used cache
+- Sort overdue by project ID for consistent tie-breaking
 
 ## Risks / Trade-offs
 
 - **Risk**: Slow query affecting modal open time
-  - **Mitigation**: Cache recent assignment query result
+  - **Mitigation**: Recent project comes from an in-memory cache (no query); only the overdue query hits the network
 
 - **Risk**: Many overdue projects
   - **Mitigation**: Strict limit of 5 suggestions total

--- a/openspec/changes/bl-031-assignment-modal-default-suggestions/proposal.md
+++ b/openspec/changes/bl-031-assignment-modal-default-suggestions/proposal.md
@@ -5,8 +5,9 @@ The assignment modal needs to show default suggestions when opened. This helps u
 ## What Changes
 
 - Show deterministic default suggestions when modal opens
-- First suggestion: most recently assigned project (across any employee/day)
-- Next 4-5 suggestions: overdue projects
+- First suggestion: most recently assigned project, taken from a temporary client last-used cache (in-memory, session-scoped)
+- Remaining suggestions: overdue projects, deduplicated against the recent project, capped at 5 total
+- When no recent project is cached, show up to 5 overdue projects
 - Define fallback behavior when recent assignment or overdue projects unavailable
 - Show German empty-state message when no suggestions available
 
@@ -20,10 +21,11 @@ The assignment modal needs to show default suggestions when opened. This helps u
 
 ## Impact
 
-- Code: New React component logic for suggestion generation + Rust overdue project query
+- Code: New React component logic for suggestion generation + client last-used cache + Rust overdue project query
 - Dependencies:
   - BL-022 for project search infrastructure (status filter, timeout, numeric sort)
   - BL-016 for assignment modal where suggestions are displayed
+  - BL-032 for the combobox shell the suggestions render into (replaces today's plain `<select>` and provides the free-text search referenced in the empty state)
 
 ## Note
 

--- a/openspec/changes/bl-031-assignment-modal-default-suggestions/specs/assignment-modal-suggestions/spec.md
+++ b/openspec/changes/bl-031-assignment-modal-default-suggestions/specs/assignment-modal-suggestions/spec.md
@@ -33,6 +33,19 @@ The system SHALL show deterministic default suggestions when assignment modal op
 - **THEN** show German message "Keine Vorschläge verfügbar"
 - **AND** modal allows free-text search
 
+### Requirement: Default suggestions fill the combobox empty state
+The system SHALL render default suggestions as the combobox empty-state content, including when the filter is cleared or Escape resets a non-empty filter.
+
+#### Scenario: Suggestions restored when filter is cleared
+- **WHEN** the filter input is cleared (manually or via Escape on a non-empty filter)
+- **THEN** the result list returns to its empty default state
+- **AND** the default suggestions (recent + overdue) are shown again
+
+#### Scenario: Keyboard navigation over suggestions
+- **WHEN** the default suggestions are displayed and the user presses Arrow Down / Arrow Up
+- **THEN** the highlighted suggestion moves accordingly
+- **AND** pressing Enter selects the highlighted suggestion into the assignment field
+
 ### Requirement: Suggestion count limit
 The system SHALL cap total suggestions at 5.
 

--- a/openspec/changes/bl-031-assignment-modal-default-suggestions/specs/assignment-modal-suggestions/spec.md
+++ b/openspec/changes/bl-031-assignment-modal-default-suggestions/specs/assignment-modal-suggestions/spec.md
@@ -45,6 +45,7 @@ The system SHALL render default suggestions as the combobox empty-state content,
 - **WHEN** the default suggestions are displayed and the user presses Arrow Down / Arrow Up
 - **THEN** the highlighted suggestion moves accordingly
 - **AND** pressing Enter selects the highlighted suggestion into the assignment field
+- **AND** the modal stays open so the user confirms with the Speichern button
 
 ### Requirement: Suggestion count limit
 The system SHALL cap total suggestions at 5.

--- a/openspec/changes/bl-031-assignment-modal-default-suggestions/specs/assignment-modal-suggestions/spec.md
+++ b/openspec/changes/bl-031-assignment-modal-default-suggestions/specs/assignment-modal-suggestions/spec.md
@@ -5,17 +5,31 @@ The system SHALL show deterministic default suggestions when assignment modal op
 
 #### Scenario: Show recent project first
 - **WHEN** modal opens
-- **THEN** first suggestion is the most recently assigned project
-- **AND** suggestions are deterministic for same state
+- **AND** the client last-used cache holds a project from an earlier assignment this session
+- **THEN** first suggestion is that most recently assigned project
+- **AND** suggestions are deterministic for the same cache and overdue state
 
-#### Scenario: Show overdue projects
+#### Scenario: Show overdue projects after a recent project
 - **WHEN** modal opens
+- **AND** a recent project exists in the client last-used cache
 - **THEN** show up to 4 overdue projects after the recent project
 - **AND** overdue projects are those with Daylite category `"Überfällig"`
 - **AND** total suggestions capped at 5
 
+#### Scenario: Show overdue projects with no recent project
+- **WHEN** modal opens
+- **AND** the client last-used cache is empty
+- **THEN** show up to 5 overdue projects
+- **AND** overdue projects are those with Daylite category `"Überfällig"`
+
+#### Scenario: Recent project that is also overdue appears once
+- **WHEN** modal opens
+- **AND** the recent project is also in the overdue results
+- **THEN** the project appears only once, in the recent (first) position
+- **AND** it is removed from the overdue portion of the list
+
 #### Scenario: Empty state handling
-- **WHEN** no recent assignment AND no overdue projects exist
+- **WHEN** the client last-used cache is empty AND no overdue projects exist
 - **THEN** show German message "Keine Vorschläge verfügbar"
 - **AND** modal allows free-text search
 
@@ -23,6 +37,7 @@ The system SHALL show deterministic default suggestions when assignment modal op
 The system SHALL cap total suggestions at 5.
 
 #### Scenario: Cap suggestions at 5
-- **WHEN** more than 5 suggestions available
+- **WHEN** more than 5 distinct suggestions available
 - **THEN** return exactly 5 suggestions
-- **AND** ordering follows: recent first, then overdue
+- **AND** ordering follows: recent first (if any), then overdue
+- **AND** a project never appears twice across the recent and overdue portions

--- a/openspec/changes/bl-031-assignment-modal-default-suggestions/tasks.md
+++ b/openspec/changes/bl-031-assignment-modal-default-suggestions/tasks.md
@@ -14,10 +14,12 @@
 
 ## 3. UI Implementation
 
-- [ ] 3.1 Add suggestions section to assignment modal
+- [ ] 3.1 Feed suggestions into BL-032's combobox empty-state list
 - [ ] 3.2 Render suggestions as clickable items
-- [ ] 3.3 Implement click handler to select suggestion
-- [ ] 3.4 Show German empty-state message when no suggestions
+- [ ] 3.3 Implement click handler to select suggestion into the assignment field
+- [ ] 3.4 Restore suggestions when the filter is cleared or Escape resets a non-empty filter
+- [ ] 3.5 Ensure keyboard nav (arrow/Enter) operates over suggestions via BL-032's mechanism
+- [ ] 3.6 Show German empty-state message when no suggestions
 
 ## 4. Fallback Handling
 
@@ -33,3 +35,4 @@
 - [ ] 5.4 Write test for empty cache: shows up to 5 overdue projects
 - [ ] 5.5 Write service tests for fallback behavior
 - [ ] 5.6 Write tests for empty state message display
+- [ ] 5.7 Write test: clearing the filter / Escape restores the default suggestions

--- a/openspec/changes/bl-031-assignment-modal-default-suggestions/tasks.md
+++ b/openspec/changes/bl-031-assignment-modal-default-suggestions/tasks.md
@@ -7,9 +7,10 @@
 
 ## 2. Suggestion Logic
 
-- [ ] 2.1 Implement query for most recently assigned project
-- [ ] 2.2 Combine overdue results with recent project first
-- [ ] 2.3 Cap total suggestions at 5
+- [ ] 2.1 Implement client last-used cache that records the last assigned project (in-memory, session-scoped)
+- [ ] 2.2 Combine overdue results with the cached recent project first
+- [ ] 2.3 Deduplicate the recent project out of the overdue portion
+- [ ] 2.4 Cap total suggestions at 5 (recent first if present, otherwise up to 5 overdue)
 
 ## 3. UI Implementation
 
@@ -26,7 +27,9 @@
 
 ## 5. Testing
 
-- [ ] 5.1 Write UI tests for suggestion ordering
+- [ ] 5.1 Write UI tests for suggestion ordering (recent first, then overdue)
 - [ ] 5.2 Write UI tests for suggestion count limit (max 5)
-- [ ] 5.3 Write service tests for fallback behavior
-- [ ] 5.4 Write tests for empty state message display
+- [ ] 5.3 Write test for dedup: recent project that is also overdue appears once
+- [ ] 5.4 Write test for empty cache: shows up to 5 overdue projects
+- [ ] 5.5 Write service tests for fallback behavior
+- [ ] 5.6 Write tests for empty state message display

--- a/openspec/changes/bl-032-assignment-modal-live-project-filter/design.md
+++ b/openspec/changes/bl-032-assignment-modal-live-project-filter/design.md
@@ -24,7 +24,8 @@ The assignment modal needs live filtering as the user types. This provides insta
 - This breaks the previous circular reference: BL-031 depends on this combobox shell, this change depends on nothing from BL-031
 
 ### Filter Trigger
-**Decision**: Show filtered results when filter input has at least 1 character
+**Decision**: Show filtered results when filter input has at least 3 characters
+- Below 3 characters no query is sent and the list stays in its empty default state
 - Debounce input to avoid excessive queries (300ms)
 - Clearing the filter returns the list to its empty default state
 
@@ -45,13 +46,13 @@ The assignment modal needs live filtering as the user types. This provides insta
 - `DayliteSearchInput` gains an optional sort field (e.g. `id` default | `name`)
 - Numeric-ID sort remains the default for all existing callers (BL-022 contract unchanged)
 - bl-032 passes sort = name; BL-031's overdue query keeps the default ID sort
-- Name sort must be case-insensitive and locale-aware for German names (ä/ö/ü); decide collation when implementing
+- Name sort uses Rust's default string ordering (byte order); German locale-aware collation (ä/ö/ü) is only worth adding if it turns out to be very simple, otherwise deferred
 
 ### Keyboard Navigation
 **Decision**: Support arrow keys and Enter over whichever list is displayed
 - Up/Down navigate the currently displayed items (filtered results or, once BL-031 lands, default suggestions)
 - Navigation operates on the unified list structure, so it covers BL-031 content automatically
-- Enter selects the highlighted project into the assignment field
+- Enter selects the highlighted project into the assignment field and leaves the modal open; the user confirms with Speichern (no save-and-close shortcut for now, can be added later if needed)
 - Escape clears a non-empty filter (returns to empty default state); on an empty filter it falls through to the modal close flow
 
 ### Escape precedence

--- a/openspec/changes/bl-032-assignment-modal-live-project-filter/design.md
+++ b/openspec/changes/bl-032-assignment-modal-live-project-filter/design.md
@@ -5,33 +5,64 @@ The assignment modal needs live filtering as the user types. This provides insta
 ## Goals / Non-Goals
 
 **Goals:**
+- Build the combobox shell (filter input + result list + keyboard navigation) that replaces today's `<select>`
 - Filter projects as user types
-- Show filtered results instead of default suggestions while filtering
-- Support keyboard navigation in filtered list
-- Restore default suggestions when filter is cleared
+- Support keyboard navigation over the displayed result list
+- Leave the result list empty when the filter is empty (a self-contained empty default state)
 
 **Non-Goals:**
+- Default suggestion content for the empty state (recent + overdue) — owned by `assignment-modal-suggestions` / BL-031
 - Persisting personal search history
 - Advanced search operators
 
 ## Decisions
 
+### Independence from default suggestions
+**Decision**: bl-032 ships first with a generic empty default state, no dependency on BL-031
+- The result list renders whatever items it is given; when the filter is empty it renders the empty-state content (nothing until BL-031 plugs in recent + overdue)
+- All default-suggestion behavior, including restoring suggestions when the filter clears or Escape is pressed, lives in BL-031
+- This breaks the previous circular reference: BL-031 depends on this combobox shell, this change depends on nothing from BL-031
+
 ### Filter Trigger
 **Decision**: Show filtered results when filter input has at least 1 character
 - Debounce input to avoid excessive queries (300ms)
-- Clear filter restores default suggestions
+- Clearing the filter returns the list to its empty default state
+
+### Trailing debounce hook
+**Decision**: Add a new trailing-edge debounce hook for search-as-you-type
+- The existing `useLeadingDebounce` fires on the first keystroke (right for week navigation, wrong for a 1-char search that would query instantly)
+- New hook waits until typing settles (300ms) before emitting, so queries fire on the settled term
+- Pair it with a request-sequence guard (monotonic request id, like `usePlanningAssignments`) so a slow earlier query cannot overwrite a newer result
 
 ### Results Display
-**Decision**: Replace default suggestions with filtered list
+**Decision**: Show filtered list in the result area
 - Show up to 5 matching projects
 - Filter to only new_status and in_progress states
-- Sort by project name for consistent results
+- Sort by project name
+
+### Sorting infrastructure
+**Decision**: Add optional sort support to `search_projects_core`; default stays numeric ID
+- `DayliteSearchInput` gains an optional sort field (e.g. `id` default | `name`)
+- Numeric-ID sort remains the default for all existing callers (BL-022 contract unchanged)
+- bl-032 passes sort = name; BL-031's overdue query keeps the default ID sort
+- Name sort must be case-insensitive and locale-aware for German names (ä/ö/ü); decide collation when implementing
 
 ### Keyboard Navigation
-**Decision**: Support arrow keys and Enter for selection
-- Up/Down to navigate filtered list
-- Enter to select highlighted project
-- Escape to clear filter and restore defaults
+**Decision**: Support arrow keys and Enter over whichever list is displayed
+- Up/Down navigate the currently displayed items (filtered results or, once BL-031 lands, default suggestions)
+- Navigation operates on the unified list structure, so it covers BL-031 content automatically
+- Enter selects the highlighted project into the assignment field
+- Escape clears a non-empty filter (returns to empty default state); on an empty filter it falls through to the modal close flow
+
+### Escape precedence
+**Decision**: Intercept Escape on `keydown` before the native `<dialog>` cancel event
+- The modal's native `cancel` event currently maps Escape → close; it has no knowledge of filter state
+- The combobox handles `keydown` and calls `preventDefault` when the filter is non-empty (clear instead of close), otherwise lets the close flow proceed
+
+### Removal of the bulk project pre-load
+**Decision**: This change removes the `<select>` and its bulk `loadProjectsForAssignmentPicker` pre-load
+- The combobox queries per settled keystroke instead of pre-loading all active projects
+- Note the interim gap: between bl-032 shipping and BL-031 landing, an empty filter shows an empty list, so the user must type to pick a project (no full-list browsing)
 
 ## Risks / Trade-offs
 
@@ -39,4 +70,7 @@ The assignment modal needs live filtering as the user types. This provides insta
   - **Mitigation**: Strict limit of 5 results
 
 - **Risk**: Rapid typing causing race conditions
-  - **Mitigation**: Debounce and cancel pending requests
+  - **Mitigation**: Trailing debounce plus request-sequence guard that drops stale responses
+
+- **Risk**: Interim regression — no full-project browsing until BL-031 lands
+  - **Mitigation**: Sequence BL-031 close behind bl-032, or accept type-to-find as the interim behavior

--- a/openspec/changes/bl-032-assignment-modal-live-project-filter/proposal.md
+++ b/openspec/changes/bl-032-assignment-modal-live-project-filter/proposal.md
@@ -4,11 +4,13 @@ The assignment modal needs live filtering as the user types. This allows quick p
 
 ## What Changes
 
-- Add text input field above default suggestions
-- While filter text is present, replace default suggestions with filtered results
-- Show first 5 matching projects from `new_status` and `in_progress` states
-- Support keyboard selection (arrow keys + enter) in filtered list
-- Restore default suggestions when input is cleared
+- Build the combobox shell that replaces today's `<select>`: a filter input plus a result list
+- The result list starts empty; filtered results appear once the user types
+- Show first 5 matching projects from `new_status` and `in_progress` states, sorted by project name
+- Support keyboard selection (arrow keys + enter) over whichever list is displayed
+- Clear filter returns the list to its empty default state (default-suggestion content is owned by BL-031)
+- Add optional sort support to `search_projects_core` (default numeric ID, opt-in name sort)
+- Add a new trailing-edge debounce hook for search-as-you-type
 
 ## Capabilities
 
@@ -20,5 +22,6 @@ The assignment modal needs live filtering as the user types. This allows quick p
 
 ## Impact
 
-- Code: New React component for filter input and filtered list
+- Code: New React combobox component (filter input + result list + keyboard nav), new trailing debounce hook, sort option added to `search_projects_core` / `DayliteSearchInput`; removes the `<select>` and the bulk `loadProjectsForAssignmentPicker` pre-load
 - Dependencies: Uses Daylite query capabilities from BL-022
+- Dependents: BL-031 plugs its default suggestions into this combobox's empty state; this change has no dependency on BL-031

--- a/openspec/changes/bl-032-assignment-modal-live-project-filter/proposal.md
+++ b/openspec/changes/bl-032-assignment-modal-live-project-filter/proposal.md
@@ -5,7 +5,7 @@ The assignment modal needs live filtering as the user types. This allows quick p
 ## What Changes
 
 - Build the combobox shell that replaces today's `<select>`: a filter input plus a result list
-- The result list starts empty; filtered results appear once the user types
+- The result list starts empty; filtered results appear once the user types at least 3 characters
 - Show first 5 matching projects from `new_status` and `in_progress` states, sorted by project name
 - Support keyboard selection (arrow keys + enter) over whichever list is displayed
 - Clear filter returns the list to its empty default state (default-suggestion content is owned by BL-031)

--- a/openspec/changes/bl-032-assignment-modal-live-project-filter/specs/assignment-modal-filter/spec.md
+++ b/openspec/changes/bl-032-assignment-modal-live-project-filter/specs/assignment-modal-filter/spec.md
@@ -5,9 +5,14 @@ The system SHALL filter projects as user types in the filter input.
 The result list starts empty; default content for the empty state is supplied by the `assignment-modal-suggestions` capability and is out of scope here.
 
 #### Scenario: Typing shows filtered results
-- **WHEN** user types at least 1 character in the filter input
+- **WHEN** user types at least 3 characters in the filter input
 - **THEN** filtered results are shown in the result list
 - **AND** only projects with status `new_status` or `in_progress` are included
+
+#### Scenario: Short filter does not query
+- **WHEN** the filter input holds fewer than 3 characters
+- **THEN** no filter query is sent
+- **AND** the result list stays in its empty default state
 
 #### Scenario: Filtered results limited to 5
 - **WHEN** user filters projects
@@ -30,6 +35,7 @@ The system SHALL support keyboard selection over whichever result list is curren
 #### Scenario: Enter to select
 - **WHEN** an item is highlighted and user presses Enter
 - **THEN** that project is selected into the assignment field
+- **AND** the modal stays open so the user confirms with the Speichern button
 
 #### Scenario: Escape clears a non-empty filter
 - **WHEN** the filter input is non-empty and user presses Escape

--- a/openspec/changes/bl-032-assignment-modal-live-project-filter/specs/assignment-modal-filter/spec.md
+++ b/openspec/changes/bl-032-assignment-modal-live-project-filter/specs/assignment-modal-filter/spec.md
@@ -2,11 +2,11 @@
 
 ### Requirement: Live project filter
 The system SHALL filter projects as user types in the filter input.
+The result list starts empty; default content for the empty state is supplied by the `assignment-modal-suggestions` capability and is out of scope here.
 
-#### Scenario: Filter replaces suggestions
-- **WHEN** user types at least 1 character in filter input
-- **THEN** default suggestions are hidden
-- **AND** filtered results are shown instead
+#### Scenario: Typing shows filtered results
+- **WHEN** user types at least 1 character in the filter input
+- **THEN** filtered results are shown in the result list
 - **AND** only projects with status `new_status` or `in_progress` are included
 
 #### Scenario: Filtered results limited to 5
@@ -14,25 +14,29 @@ The system SHALL filter projects as user types in the filter input.
 - **THEN** maximum 5 matching projects are shown
 - **AND** results are sorted by project name
 
-#### Scenario: Clear filter restores suggestions
+#### Scenario: Clear filter empties the result list
 - **WHEN** user clears the filter input
 - **THEN** filtered results are hidden
-- **AND** default suggestions are restored
+- **AND** the result list returns to its empty default state
 
 ### Requirement: Keyboard navigation
-The system SHALL support keyboard selection in filtered list.
+The system SHALL support keyboard selection over whichever result list is currently displayed (filtered results or the empty-state default content).
 
 #### Scenario: Arrow key navigation
-- **WHEN** filtered list is shown and user presses Arrow Down
-- **THEN** next project is highlighted
-- **AND** pressing Arrow Up highlights previous project
+- **WHEN** a result list is shown and user presses Arrow Down
+- **THEN** the next item is highlighted
+- **AND** pressing Arrow Up highlights the previous item
 
 #### Scenario: Enter to select
-- **WHEN** a project is highlighted and user presses Enter
-- **THEN** that project is selected
-- **AND** modal closes with selection
+- **WHEN** an item is highlighted and user presses Enter
+- **THEN** that project is selected into the assignment field
 
-#### Scenario: Escape to clear filter
-- **WHEN** user presses Escape
-- **THEN** filter input is cleared
-- **AND** default suggestions are restored
+#### Scenario: Escape clears a non-empty filter
+- **WHEN** the filter input is non-empty and user presses Escape
+- **THEN** the filter input is cleared
+- **AND** the result list returns to its empty default state
+- **AND** the modal does not close
+
+#### Scenario: Escape closes the modal when filter is empty
+- **WHEN** the filter input is empty and user presses Escape
+- **THEN** the modal close flow runs (existing unsaved-changes guard applies)

--- a/openspec/changes/bl-032-assignment-modal-live-project-filter/tasks.md
+++ b/openspec/changes/bl-032-assignment-modal-live-project-filter/tasks.md
@@ -1,25 +1,38 @@
-## 1. Filter Input
+## 1. Sort Infrastructure (Rust, TDD)
 
-- [ ] 1.1 Add text input field above suggestions
-- [ ] 1.2 Implement debounce (300ms) on input
-- [ ] 1.3 Clear filter restores default suggestions
+- [ ] 1.1 Write failing test: `search_projects_core` sorts by name when sort = name
+- [ ] 1.2 Add optional sort field to `DayliteSearchInput` (default numeric ID)
+- [ ] 1.3 Implement name sort (case-insensitive, locale-aware for ä/ö/ü); keep ID as default
+- [ ] 1.4 Confirm existing callers default to ID sort (BL-022 contract unchanged)
 
-## 2. Live Filtering
+## 2. Trailing Debounce Hook
 
-- [ ] 2.1 Call BL-022 query with filter text
-- [ ] 2.2 Replace default suggestions with filtered results
-- [ ] 2.3 Limit results to 5
-- [ ] 2.4 Filter to new_status and in_progress only
+- [ ] 2.1 Add new trailing-edge debounce hook for search-as-you-type (300ms)
+- [ ] 2.2 Add request-sequence guard so stale responses are dropped
 
-## 3. Keyboard Navigation
+## 3. Combobox Shell
 
-- [ ] 3.1 Add arrow key handlers for list navigation
-- [ ] 3.2 Add Enter key to confirm selection
-- [ ] 3.3 Add Escape key to clear filter
+- [ ] 3.1 Replace the `<select>` with a filter input + result list
+- [ ] 3.2 Remove the bulk `loadProjectsForAssignmentPicker` pre-load
+- [ ] 3.3 Leave the result list empty when the filter is empty
 
-## 4. Testing
+## 4. Live Filtering
 
-- [ ] 4.1 Write UI tests for replace/restore behavior on input change
-- [ ] 4.2 Write service tests for max-5 and status filter guarantees
-- [ ] 4.3 Write UI tests for keyboard selection
-- [ ] 4.4 Write tests for debounce behavior
+- [ ] 4.1 Call BL-022 query with filter text (sort = name)
+- [ ] 4.2 Show filtered results in the result list
+- [ ] 4.3 Limit results to 5
+- [ ] 4.4 Filter to new_status and in_progress only
+
+## 5. Keyboard Navigation
+
+- [ ] 5.1 Add arrow key handlers operating on the displayed list (generic, covers BL-031 content)
+- [ ] 5.2 Add Enter key to select highlighted project into the assignment field
+- [ ] 5.3 Intercept Escape on keydown: clear non-empty filter, else fall through to modal close
+
+## 6. Testing
+
+- [ ] 6.1 Write UI tests for filter → results and clear → empty default state
+- [ ] 6.2 Write service tests for max-5, status filter, and name-sort guarantees
+- [ ] 6.3 Write UI tests for keyboard selection
+- [ ] 6.4 Write tests for trailing debounce and stale-response dropping
+- [ ] 6.5 Write tests for Escape precedence (clear vs close)

--- a/openspec/changes/bl-032-assignment-modal-live-project-filter/tasks.md
+++ b/openspec/changes/bl-032-assignment-modal-live-project-filter/tasks.md
@@ -2,7 +2,7 @@
 
 - [ ] 1.1 Write failing test: `search_projects_core` sorts by name when sort = name
 - [ ] 1.2 Add optional sort field to `DayliteSearchInput` (default numeric ID)
-- [ ] 1.3 Implement name sort (case-insensitive, locale-aware for ä/ö/ü); keep ID as default
+- [ ] 1.3 Implement name sort using Rust default ordering (locale-aware ä/ö/ü only if trivial); keep ID as default
 - [ ] 1.4 Confirm existing callers default to ID sort (BL-022 contract unchanged)
 
 ## 2. Trailing Debounce Hook
@@ -18,7 +18,7 @@
 
 ## 4. Live Filtering
 
-- [ ] 4.1 Call BL-022 query with filter text (sort = name)
+- [ ] 4.1 Query only when the filter has at least 3 characters (sort = name)
 - [ ] 4.2 Show filtered results in the result list
 - [ ] 4.3 Limit results to 5
 - [ ] 4.4 Filter to new_status and in_progress only


### PR DESCRIPTION
Updates the design and specification for assignment modal default suggestions to use a client-side last-used cache instead of querying CalDAV history.

Key changes:

- **Cache strategy**: Replace CalDAV history query with an in-memory, session-scoped last-used cache that records the most recently assigned project during the current session.
  This avoids slow multi-calendar scans and keeps behavior deterministic.

- **Suggestion ordering**: Recent project (from cache) appears first, followed by up to 4 overdue projects, capped at 5 total.
  When cache is empty, show up to 5 overdue projects.

- **Deduplication**: If the recent project is also in the overdue results, it appears only once in the recent position and is removed from the overdue portion.

- **Empty state**: Show "Keine Vorschläge verfügbar" only when both the cache is empty and no overdue projects exist.

- **Task updates**: Clarify implementation steps to include cache creation, deduplication logic, and additional test scenarios for cache behavior and dedup cases.

- **Dependency clarification**: Note that BL-032 provides the combobox shell that these suggestions render into.

All display text remains in German; behavior is now more predictable for users within a session.

https://claude.ai/code/session_01ALVkMwqpDvEeZDf6dS5jQP