### PR TITLE
Refactor Specta bindings generation and add automated CI workflow

### DIFF
--- a/.github/workflows/update-bindings.yml
+++ b/.github/workflows/update-bindings.yml
@@ -1,0 +1,41 @@
+name: Update Bindings
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src-tauri/src/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-bindings-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-bindings:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Regenerate Tauri Specta bindings
+        run: cargo test --manifest-path src-tauri/Cargo.toml regenerate_generated_bindings
+
+      - name: Commit and push bindings if changed
+        run: |
+          if git diff --quiet -- src/generated; then
+            echo "Bindings are up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/generated
+          git commit -m "chore: update generated Tauri bindings"
+          git push

--- a/.github/workflows/update-bindings.yml
+++ b/.github/workflows/update-bindings.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "src-tauri/src/**"
+  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -5,56 +5,59 @@ It is built with Tauri, React, TypeScript, and Bun.
 
 ## Current Scope
 
-The current implementation focuses on the technical and domain foundation for planning.
-The backlog is currently centered on weekly assignment workflows, iCal synchronization, and Planradar project linking.
+The current implementation covers the weekly planning view with full assignment CRUD, CalDAV synchronization, Daylite project/employee data, and German holiday display.
+The backlog is now centered on Planradar project linking, assignment modal quality-of-life features, and drag-and-drop replanning.
 
 ### Implemented
 
 - Daylite authentication with refresh-token rotation and documented token flow in [docs/daylite-authentication-flow.md](/Users/flori/dev/lkr-planner/docs/daylite-authentication-flow.md)
 - Typed Daylite API foundation for project and contact read/search operations
 - Local application store for persisted configuration and cached integration data
+- Secure OS-level token and credential storage via the system keychain (`keyring-core`)
 - Employee source switched to Daylite contacts (`Monteur` category)
-- Employee iCal URLs are read from and written back to Daylite contact `urls`
+- Employee ZEP CalDAV calendar URLs are read from and written back to Daylite contact `urls`, with connection validation and diagnostics
 - Daylite project overview rendered below the planning table
+- Weekly planning table backed by real, persisted assignment data instead of dummy data
+- Assignment modal CRUD flow (create, edit, delete) for weekly planning
+- Live Daylite project search/filter in the assignment modal
+- Calendar cell composition and rendering for assignments, holidays, absences, and appointments
+- Employee absence display from the ZEP absence calendar
+- German holiday import for the week view (Nager.Date API)
+- Weekend visibility toggle for the planning table
+- CalDAV synchronization for assignment create/update/delete operations
+- Record/replay HTTP (VCR) testing infrastructure for integration tests
 - ADR-based architecture documentation in [docs/adr](/Users/flori/dev/lkr-planner/docs/adr)
 
 ### Planned / In Backlog
 
-- Validate and test employee primary and absence iCal sources
-- Replace remaining dummy assignment data with persisted planning state
-- Assignment modal CRUD flow for weekly planning
-- Default suggestions and live Daylite project search in the assignment modal
+- Default suggestions in the assignment modal
 - Next-day quick-add suggestion behavior
-- German holiday import for week view
-- Calendar cell composition and rendering for assignments, holidays, absences, and appointments
 - Deterministic daily time-slot allocation for assignment sync
-- iCal synchronization for assignment create/update/delete operations
+- Drag-and-drop of assignment cards across days and employees, including in-day reordering
 - Planradar API client, existing-project linking, project creation, and archived-project reactivation
-- Secure OS-level token storage instead of plain-text local persistence
-- Record/replay HTTP testing infrastructure for integration tests
+- Daylite-to-Planradar project comparison
 
 ## Product Direction
 
 Daylite remains the source of truth for projects and employees.
-The app is intended to support a planner workflow where assignments are managed in a weekly view, enriched with iCal context, and later synchronized to external systems where needed.
+The app supports a planner workflow where assignments are managed in a weekly view, enriched with ZEP CalDAV context, and synchronized to external systems where needed.
 
 ### Daylite
 
 The application integrates with the [Daylite API](https://developer.daylite.app/reference/getting-started).
 Daylite is the source of truth for project and employee master data.
-Current work already covers authentication, token refresh handling, project reads, and employee contact/iCal configuration.
+Current work covers authentication, token refresh handling, project reads, and employee contact/iCal configuration.
 
 ### Planradar
 
 The application is planned to integrate with the [Planradar API](https://help.planradar.com/hc/en-gb/articles/15480453097373-Open-APIs).
 Planradar synchronization is not implemented yet.
-The active backlog covers the client foundation plus flows to link existing projects, create new linked projects, and reactivate archived linked projects.
+The active backlog covers the client foundation plus flows to compare, link existing projects, create new linked projects, and reactivate archived linked projects.
 
-### iCal
+### iCal / CalDAV
 
-iCal is used as planning context and as a future synchronization target for employee assignments.
-Current implementation covers storing the two employee iCal URLs in Daylite.
-Validation, diagnostics, cell composition, and write synchronization are still planned backlog items.
+ZEP CalDAV calendars are used as planning context and as the synchronization target for employee assignments.
+Current implementation covers storing employee primary and absence calendar URLs in Daylite, validating and diagnosing those connections, rendering absences and assignments in the weekly grid, and writing assignment create/update/delete operations back to CalDAV.
 
 ## Development
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,38 +3,45 @@ use tauri_plugin_updater::UpdaterExt;
 mod integrations;
 pub mod secret_manager;
 
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
-    let specta_builder =
-        tauri_specta::Builder::<tauri::Wry>::new().commands(tauri_specta::collect_commands![
-            integrations::health::check_health,
-            integrations::local_store::load_local_store,
-            integrations::local_store::save_local_store,
-            integrations::calendar::commands::load_week_events,
-            integrations::holidays::get_holidays_for_week,
-            integrations::daylite::auth::daylite_connect_refresh_token,
-            integrations::daylite::projects::daylite_list_projects,
-            integrations::daylite::projects::daylite_search_projects,
-            integrations::daylite::contacts::commands::daylite_list_contacts,
-            integrations::daylite::contacts::commands::daylite_list_cached_contacts,
-            integrations::daylite::contacts::commands::daylite_update_contact_ical_urls,
-            integrations::calendar::commands::create_assignment,
-            integrations::calendar::commands::update_assignment,
-            integrations::calendar::commands::delete_assignment,
-            integrations::zep::commands::zep_save_credentials,
-            integrations::zep::commands::zep_load_credentials,
-            integrations::zep::commands::zep_test_credentials,
-            integrations::zep::commands::zep_discover_calendars,
-            integrations::zep::commands::zep_save_and_test_calendar,
-        ]);
+fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
+    tauri_specta::Builder::<tauri::Wry>::new().commands(tauri_specta::collect_commands![
+        integrations::health::check_health,
+        integrations::local_store::load_local_store,
+        integrations::local_store::save_local_store,
+        integrations::calendar::commands::load_week_events,
+        integrations::holidays::get_holidays_for_week,
+        integrations::daylite::auth::daylite_connect_refresh_token,
+        integrations::daylite::projects::daylite_list_projects,
+        integrations::daylite::projects::daylite_search_projects,
+        integrations::daylite::contacts::commands::daylite_list_contacts,
+        integrations::daylite::contacts::commands::daylite_list_cached_contacts,
+        integrations::daylite::contacts::commands::daylite_update_contact_ical_urls,
+        integrations::calendar::commands::create_assignment,
+        integrations::calendar::commands::update_assignment,
+        integrations::calendar::commands::delete_assignment,
+        integrations::zep::commands::zep_save_credentials,
+        integrations::zep::commands::zep_load_credentials,
+        integrations::zep::commands::zep_test_credentials,
+        integrations::zep::commands::zep_discover_calendars,
+        integrations::zep::commands::zep_save_and_test_calendar,
+    ])
+}
 
-    #[cfg(debug_assertions)]
+fn export_bindings(specta_builder: &tauri_specta::Builder<tauri::Wry>) {
     specta_builder
         .export(
             specta_typescript::Typescript::default().header("// @ts-nocheck"),
             "../src/generated/tauri.ts",
         )
         .expect("failed to export tauri specta bindings");
+}
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    let specta_builder = specta_builder();
+
+    #[cfg(debug_assertions)]
+    export_bindings(&specta_builder);
 
     tauri::Builder::default()
         .setup(|app| {
@@ -85,4 +92,14 @@ fn format_update_error<E: std::fmt::Display>(result: Result<(), E>) -> Option<St
     result
         .err()
         .map(|error| format!("Update check failed in background task: {error}"))
+}
+
+#[cfg(test)]
+mod bindings {
+    use super::{export_bindings, specta_builder};
+
+    #[test]
+    fn regenerate_generated_bindings() {
+        export_bindings(&specta_builder());
+    }
 }


### PR DESCRIPTION
Extract the Specta builder and bindings export logic into reusable functions to enable automated regeneration of TypeScript bindings in CI.

Key changes:
- Extracted `specta_builder()` function to centralize command registration and builder configuration
- Extracted `export_bindings()` function to handle TypeScript bindings export
- Added `bindings` test module with `regenerate_generated_bindings` test to allow CI-driven regeneration
- Added GitHub Actions workflow (`update-bindings.yml`) that runs on changes to `src-tauri/src/**`, regenerates bindings via `cargo test`, and commits changes if needed
- Updated README.md to reflect completed features (CalDAV synchronization, assignment CRUD, absence display, holiday import, weekend toggle) and refined backlog priorities

This enables keeping generated TypeScript bindings in sync with Rust command definitions automatically, reducing manual maintenance and preventing drift between backend and frontend type definitions.

https://claude.ai/code/session_01J19jr1HAkfRoJ35D57PCwY