### PR TITLE
Propose improved CalDAV caching for responsiveness

### DIFF
--- a/openspec/changes/caldav-caching-improvements/.openspec.yaml
+++ b/openspec/changes/caldav-caching-improvements/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-03

--- a/openspec/changes/caldav-caching-improvements/design.md
+++ b/openspec/changes/caldav-caching-improvements/design.md
@@ -1,0 +1,56 @@
+## Context
+
+`load_week_events` (`src-tauri/src/integrations/calendar/commands.rs`) fetches every employee's primary and absence calendar directly from CalDAV on each call, with no backend cache.
+A new `reqwest::Client` is constructed per command call (`load_week_events`, `create_assignment`, `update_assignment`, `delete_assignment`), discarding connection keep-alive.
+The frontend hook `use-planning-assignments.ts` already keeps an in-memory, per-week cache with no TTL, prefetches adjacent weeks, and wipes the entire cache via `reloadAssignments()` after any write.
+ADR 0007 already established the pattern for this kind of cache (TTL-based, in-memory, request coalescing, stale-on-error fallback) for Daylite project lookups; this change applies the same pattern to CalDAV week events, but in the Rust backend rather than the frontend, since CalDAV is called exclusively from Tauri commands.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Avoid redundant CalDAV `REPORT` requests for week ranges already fetched recently.
+- Reuse one `reqwest::Client` across all CalDAV commands for connection reuse.
+- Invalidate only the affected employee/week cache entry on write, instead of a full wipe.
+- Coalesce concurrent identical week fetches (e.g. rapid navigation) into a single in-flight request.
+
+**Non-Goals:**
+- No durable/offline cache; the cache remains process-local in-memory, matching ADR 0007's scope for Daylite.
+- No change to the CalDAV wire protocol, VEVENT format, or write semantics (create/update/delete still hit CalDAV directly, then invalidate the cache).
+- No change to the frontend's own week-cache data structure beyond how it invalidates entries after writes.
+
+## Decisions
+
+### Backend cache location and shape
+Add a `CaldavEventCache` in `src-tauri/src/integrations/calendar/`, keyed by `(employee_id, calendar_url, week_start)`, storing the resolved event list and a `fetched_at` timestamp.
+Default TTL: 30 seconds, matching ADR 0007's Daylite cache, since CalDAV data changes at a similar human-editing cadence.
+Alternative considered: caching at the raw CalDAV response (XML) level instead of resolved events. Rejected because resolved events already include Daylite project references, which are the expensive part to recompute, and caching post-resolution avoids re-running that resolution on every cache hit.
+
+### Shared HTTP client
+Move `reqwest::Client` construction into a single `once_cell`/`OnceLock`-backed singleton (or pass a shared client held in Tauri managed state), replacing the per-call `reqwest::Client::new()` in `commands.rs`.
+Alternative considered: leaving per-call clients but tuning connection pool settings. Rejected because it does not remove the per-call TCP/TLS handshake overhead that a shared client's connection pool avoids.
+
+### Invalidation strategy
+On `create_assignment` / `update_assignment` / `delete_assignment`, invalidate only the cache entry for `(employee_id, calendar_url, week_start)` derived from the affected event's date, then let the next read repopulate it.
+The frontend's `reloadAssignments()` full-wipe call is replaced with a targeted call that clears only the affected week from its own cache, mirroring the backend's targeted invalidation so both layers stay consistent.
+Alternative considered: TTL-only invalidation (no explicit invalidation on write). Rejected because a 30s stale window after a user's own edit would be a visible regression versus current behavior, where writes are followed by an immediate full reload.
+
+### Request coalescing
+Use an in-flight request map (`(employee_id, calendar_url, week_start) -> shared future`) so concurrent identical fetches await the same CalDAV request rather than issuing duplicates, following the same coalescing approach as ADR 0007.
+
+## Risks / Trade-offs
+
+- [Stale data within TTL window if CalDAV is edited outside the app] → Mitigate by keeping TTL short (30s) and the existing manual week-navigation refetch behavior; users editing CalDAV externally already tolerate light staleness under the frontend cache today.
+- [Shared `reqwest::Client` state adds Tauri-managed-state complexity] → Mitigate by following the existing Daylite integration's pattern for holding shared clients/caches in managed state.
+- [Targeted invalidation depends on correctly deriving the week key from the affected event's date] → Mitigate with unit tests covering week-boundary edge cases (event near week start/end).
+
+## Migration Plan
+
+- Implement the backend cache and shared client behind the existing `load_week_events`/`create_assignment`/`update_assignment`/`delete_assignment` command signatures — no frontend contract changes required beyond invalidation calls.
+- Add `cargo test` coverage for cache hit/miss/TTL expiry/invalidation before wiring it into the commands (red/green TDD per CLAUDE.md).
+- Update `use-planning-assignments.ts` to call targeted invalidation instead of `reloadAssignments()` after writes.
+- Document the decision as a new ADR once implemented, following the numbering after `0012`.
+- No rollback data migration needed since the cache is in-memory only; reverting the commit fully reverts behavior.
+
+## Open Questions
+
+- Should the backend cache TTL be configurable via local settings (as ADR 0007 flagged as future work for Daylite), or is a fixed 30s constant sufficient for this change?

--- a/openspec/changes/caldav-caching-improvements/design.md
+++ b/openspec/changes/caldav-caching-improvements/design.md
@@ -53,4 +53,4 @@ Use an in-flight request map (`(employee_id, calendar_url, week_start) -> shared
 
 ## Open Questions
 
-- Should the backend cache TTL be configurable via local settings (as ADR 0007 flagged as future work for Daylite), or is a fixed 30s constant sufficient for this change?
+None — confirmed with the user that a fixed 30s TTL constant is sufficient for this change; no configurable TTL is needed.

--- a/openspec/changes/caldav-caching-improvements/proposal.md
+++ b/openspec/changes/caldav-caching-improvements/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Every week navigation re-issues full CalDAV `REPORT` requests for each employee's primary and absence calendar, and every Tauri command opens a brand-new `reqwest::Client`.
+There is no backend cache at all, so responsiveness depends entirely on the frontend's in-memory, per-session week cache, which is wiped completely on any write.
+Introducing a backend-side cache with targeted invalidation removes redundant network round-trips and keeps the UI responsive after edits.
+
+## What Changes
+
+- Add an in-memory, TTL-based cache in the Rust backend for CalDAV week event fetches, keyed by employee + calendar URL + week range.
+- Reuse a single shared `reqwest::Client` instance across CalDAV commands instead of constructing one per call.
+- Coalesce concurrent identical fetch requests (e.g. rapid week navigation) into a single in-flight CalDAV request.
+- Replace the frontend's full-cache wipe on write (`reloadAssignments()`) with targeted invalidation of only the affected employee/week entry, backed by the new backend cache.
+- Fetch missing Daylite project references concurrently instead of sequentially when resolving events for a loaded week.
+
+## Capabilities
+
+### New Capabilities
+- `caldav-event-caching`: Backend-side caching layer for CalDAV week event fetches, covering TTL-based freshness, targeted invalidation on write, request coalescing, and shared HTTP client reuse.
+
+### Modified Capabilities
+- `assignment-persistence`: "Load assignments from CalDAV" and "Week navigation with live data" requirements change from always-live CalDAV queries with frontend-only prefetching to cache-backed loads that also serve fresh data after targeted invalidation.
+
+## Impact
+
+- `src-tauri/src/integrations/calendar/commands.rs`: add cache lookup/store around `load_week_events`, shared `reqwest::Client`, targeted invalidation on `create_assignment`/`update_assignment`/`delete_assignment`.
+- `src-tauri/src/integrations/calendar/caldav.rs`: no protocol changes expected; caching sits above the HTTP layer.
+- `src/app/hooks/use-planning-assignments.ts`: replace full-cache wipe with targeted invalidation calls after write operations.
+- `docs/adr/`: new ADR documenting the backend caching strategy (TTL, invalidation, client reuse), following the precedent set by ADR 0007 (Daylite project cache).
+- Tests: new `cargo test` coverage for cache hit/miss/invalidation behavior; existing CalDAV VCR-style tests remain unaffected since caching sits above the HTTP transport.

--- a/openspec/changes/caldav-caching-improvements/specs/assignment-persistence/spec.md
+++ b/openspec/changes/caldav-caching-improvements/specs/assignment-persistence/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Load assignments from CalDAV
+The system SHALL load assignment events from each employee's primary CalDAV calendar, served through the backend's CalDAV event cache.
+
+#### Scenario: Load assignments for week
+- **WHEN** user navigates to a week
+- **THEN** VEVENTs for that week are fetched from the backend cache when a fresh entry exists, or from each employee's primary CalDAV calendar otherwise
+- **AND** displayed in the planning grid
+
+#### Scenario: No events exist for week
+- **WHEN** loading events for a week with no calendar entries
+- **THEN** empty cells are shown
+- **AND** user can create new assignments (via BL-016)
+
+#### Scenario: Employee has no primary calendar configured
+- **WHEN** an employee has no `zepPrimaryCalendar` setting
+- **THEN** their row shows empty cells without triggering a fetch or error
+
+### Requirement: Week navigation with live data
+The system SHALL use CalDAV, via the backend cache, as the data source for all week navigation, keeping data fresh through targeted invalidation rather than a full cache wipe.
+
+#### Scenario: Navigate between weeks
+- **WHEN** user navigates to a different week
+- **THEN** cached or freshly fetched CalDAV data for the new week's date range is displayed
+
+#### Scenario: Pre-fetch adjacent weeks
+- **WHEN** a week is loaded
+- **THEN** the previous and next weeks are silently pre-fetched into the frontend cache
+- **AND** navigation to an adjacent week displays instantly without a loading state
+
+#### Scenario: Cache invalidated after own write
+- **WHEN** the user creates, updates, or deletes an assignment
+- **THEN** only the affected employee's week cache entry is invalidated in both the backend and frontend caches
+- **AND** other cached weeks remain untouched
+- **AND** the affected week reflects the change on next display without a full application reload

--- a/openspec/changes/caldav-caching-improvements/specs/caldav-event-caching/spec.md
+++ b/openspec/changes/caldav-caching-improvements/specs/caldav-event-caching/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Backend caches CalDAV week events
+The system SHALL cache resolved CalDAV week events in the backend, keyed by employee, calendar URL, and week start.
+
+#### Scenario: Cache hit within TTL
+- **WHEN** `load_week_events` is called for an employee/week already cached within the last 30 seconds
+- **THEN** the cached event list is returned
+- **AND** no CalDAV request is issued
+
+#### Scenario: Cache miss after TTL expiry
+- **WHEN** `load_week_events` is called for an employee/week whose cache entry is older than 30 seconds
+- **THEN** a fresh CalDAV request is issued
+- **AND** the cache entry is replaced with the new result and timestamp
+
+#### Scenario: Cache miss for uncached week
+- **WHEN** `load_week_events` is called for an employee/week with no existing cache entry
+- **THEN** a CalDAV request is issued
+- **AND** the result is stored in the cache
+
+### Requirement: Concurrent identical fetches are coalesced
+The system SHALL coalesce concurrent identical CalDAV week-event fetches into a single in-flight request.
+
+#### Scenario: Rapid duplicate requests
+- **WHEN** two calls for the same employee/calendar/week arrive while a fetch for that key is already in flight
+- **THEN** both calls await the same underlying CalDAV request
+- **AND** exactly one CalDAV request is issued
+
+### Requirement: Targeted cache invalidation on write
+The system SHALL invalidate only the affected employee/week cache entry when an assignment is created, updated, or deleted.
+
+#### Scenario: Invalidate on create
+- **WHEN** `create_assignment` succeeds
+- **THEN** the cache entry for that employee's calendar and the assignment's week is removed
+- **AND** other employees' and weeks' cache entries remain unaffected
+
+#### Scenario: Invalidate on update
+- **WHEN** `update_assignment` succeeds
+- **THEN** the cache entry for that employee's calendar and the assignment's week is removed
+
+#### Scenario: Invalidate on delete
+- **WHEN** `delete_assignment` succeeds
+- **THEN** the cache entry for that employee's calendar and the assignment's week is removed
+
+### Requirement: Stale-on-error fallback
+The system SHALL serve the last cached result if a refresh fetch fails and a previous successful entry exists.
+
+#### Scenario: Refresh fails with existing cache entry
+- **WHEN** a CalDAV fetch fails
+- **AND** a previous successful cache entry exists for that employee/calendar/week
+- **THEN** the stale cached data is returned
+- **AND** no error is surfaced to the caller for that fetch
+
+#### Scenario: Refresh fails with no existing cache entry
+- **WHEN** a CalDAV fetch fails
+- **AND** no previous cache entry exists for that employee/calendar/week
+- **THEN** the failure is propagated as an error
+
+### Requirement: Shared HTTP client for CalDAV requests
+The system SHALL reuse a single HTTP client instance across all CalDAV commands instead of constructing a new client per call.
+
+#### Scenario: Multiple CalDAV commands reuse the same client
+- **WHEN** `load_week_events`, `create_assignment`, `update_assignment`, and `delete_assignment` are called during a session
+- **THEN** all of them use the same shared HTTP client instance
+- **AND** no per-call client construction occurs

--- a/openspec/changes/caldav-caching-improvements/tasks.md
+++ b/openspec/changes/caldav-caching-improvements/tasks.md
@@ -1,0 +1,40 @@
+## 1. Backend cache module
+
+- [ ] 1.1 Write failing `cargo test`s for `CaldavEventCache`: cache miss, cache hit within TTL, cache miss after TTL expiry, targeted invalidation
+- [ ] 1.2 Implement `CaldavEventCache` in `src-tauri/src/integrations/calendar/` keyed by `(employee_id, calendar_url, week_start)` with 30s TTL, satisfying the tests
+- [ ] 1.3 Write failing tests for request coalescing of concurrent identical fetches
+- [ ] 1.4 Implement in-flight request coalescing for the cache, satisfying the tests
+- [ ] 1.5 Write failing tests for stale-on-error fallback (return last good entry when a refresh fails)
+- [ ] 1.6 Implement stale-on-error fallback, satisfying the tests
+
+## 2. Shared HTTP client
+
+- [ ] 2.1 Add a shared `reqwest::Client` held in Tauri managed state (or `OnceLock`), following the existing Daylite integration's pattern
+- [ ] 2.2 Replace per-call `reqwest::Client::new()` in `load_week_events`, `create_assignment`, `update_assignment`, and `delete_assignment` (`src-tauri/src/integrations/calendar/commands.rs`) with the shared client
+
+## 3. Wire cache into commands
+
+- [ ] 3.1 Update `load_week_events` to consult `CaldavEventCache` before issuing CalDAV requests, storing fresh results on miss
+- [ ] 3.2 Add targeted cache invalidation calls to `create_assignment`, `update_assignment`, and `delete_assignment` for the affected employee/week
+- [ ] 3.3 Add `cargo test` coverage for week-boundary edge cases when deriving the invalidation key from an event's date
+
+## 4. Concurrent Daylite project resolution
+
+- [ ] 4.1 Change the sequential loop resolving missing Daylite project refs in `load_week_events` (`commands.rs`) to resolve them concurrently
+
+## 5. Frontend targeted invalidation
+
+- [ ] 5.1 Replace the full-cache wipe (`reloadAssignments()`) after writes in `src/app/hooks/use-planning-assignments.ts` with a targeted invalidation of the affected week
+- [ ] 5.2 Add/update TS unit tests (`bun test`) covering targeted invalidation leaves other cached weeks untouched
+
+## 6. Documentation
+
+- [ ] 6.1 Write ADR `docs/adr/0013-caldav-event-caching.md` documenting the backend cache decision, following the ADR 0007 format
+- [ ] 6.2 Run `bun run test:docs` after adding the ADR
+
+## 7. Verification
+
+- [ ] 7.1 Run `cargo test` and confirm all new and existing CalDAV tests pass
+- [ ] 7.2 Run `bun test` and confirm all new and existing frontend tests pass
+- [ ] 7.3 Run `bun lint` and fix any issues
+- [ ] 7.4 Manually verify in the running app: week navigation is faster on repeat visits, and an edit is reflected immediately without a full reload

--- a/openspec/changes/color-coded-events/.openspec.yaml
+++ b/openspec/changes/color-coded-events/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-03

--- a/openspec/changes/color-coded-events/design.md
+++ b/openspec/changes/color-coded-events/design.md
@@ -52,22 +52,22 @@ Reuse the codebase's existing `bg-<token>/<opacity>` convention to encode intens
 - Unmatched → `bg-info/30` (unchanged default)
 
 ### Code matching rule
-Match the absence title's leading token (split on whitespace/`-`/`:`) case-insensitively against the six codes, rather than a bare substring search — a naive "contains" check risks false positives for two-letter codes like `SU` appearing inside unrelated words. This assumption about Zep's title format (code as a leading token) should be verified against real title samples during implementation; if Zep formats titles differently, the matching rule is the only piece that needs adjusting.
+Match the absence title against the six codes.
+Trim the title and check for equivalence to match the title.
 
 ### Conflict indicator: status color, not a category
-When a cell contains both an absence event and an assignment (`kind === "assignment"`) event for the same employee/day, add a red conflict indicator — a `ring-2 ring-error` (or equivalent border) on the cell plus a small warning icon (Lucide) with a German tooltip/label (e.g. `"Termin während Abwesenheit"`), never color alone, per the dataviz skill's status-color rule that state (good/warning/critical) must never be encoded as "just another category color."
+When a cell contains both an absence event and an assignment (`kind === "assignment"`) event for the same employee/day, add a red conflict indicator — a `ring-2 ring-error` (or equivalent border) on the cell plus a small warning icon (Lucide).
 Bare (non-assignment) events also trigger the conflict indicator.
 
 ## Risks / Trade-offs
 
-- [Code-matching assumption about title format is unverified against real Zep data] → Mitigate by isolating the matching rule behind a single function with test coverage that's easy to adjust if the real title format differs (e.g. code embedded rather than leading).
 - [`vacation` ↔ `special` CVD separation sits at the floor, not the full target] → Mitigated by the event title always being visible as text on the card (secondary encoding), per the skill's floor-band rule.
 - [Dark-surface contrast for the three new tokens sits below 3:1 at low opacity] → Accepted, same as the app's existing absence/status color usage (all applied as low-opacity washes with the title text as the readable channel, not the fill itself).
 
 ## Migration Plan
 
 - Add the three new CSS custom properties to `src/app.css` first (additive, no visual change yet).
-- Implement and test the code classifier and conflict detector in `src/app/types.ts`.
+- Implement and test the conflict detector in `src/app/types.ts`.
 - Wire the new colors and conflict indicator into `toCellEvent()`/`timetable-cell.tsx`.
 - Update the `employee-absence-display` spec delta and archive it alongside the code change.
 

--- a/openspec/changes/color-coded-events/design.md
+++ b/openspec/changes/color-coded-events/design.md
@@ -56,7 +56,7 @@ Match the absence title's leading token (split on whitespace/`-`/`:`) case-insen
 
 ### Conflict indicator: status color, not a category
 When a cell contains both an absence event and an assignment (`kind === "assignment"`) event for the same employee/day, add a red conflict indicator — a `ring-2 ring-error` (or equivalent border) on the cell plus a small warning icon (Lucide) with a German tooltip/label (e.g. `"Termin während Abwesenheit"`), never color alone, per the dataviz skill's status-color rule that state (good/warning/critical) must never be encoded as "just another category color."
-Bare (non-assignment) events do not trigger the conflict indicator — only assignment events count as "an appointment" for this purpose.
+Bare (non-assignment) events also trigger the conflict indicator.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/color-coded-events/design.md
+++ b/openspec/changes/color-coded-events/design.md
@@ -1,0 +1,50 @@
+## Context
+
+Absence event color is decided purely in the frontend, in `toCellEvent()` (`src/app/types.ts:39-55`), which currently assigns `bg-info/30` to every event with `kind === "absence"`.
+Absence titles come from the iCal `SUMMARY` field with no structured category data — the `CalendarEventKind` enum only distinguishes `Assignment | Bare | Absence`, and no VEVENT `CATEGORIES` property is parsed anywhere in the CalDAV integration.
+The user confirmed (via clarification) that classification should be based on keyword-matching the German title text, scoped to absence events only; assignment and bare event coloring are unaffected.
+Daylite project-status colors already occupy `secondary`, `success`, `neutral`, `warning`, and `primary` (`projectStatusToColor`, `src/app/types.ts:19-36`), so absence categories must pick from the remaining DaisyUI semantic tokens (`info`, `accent`, `error`) to avoid visually colliding with assignment cards in the same grid.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Distinguish common absence categories (sick, special/training, vacation/other) by color in the timetable.
+- Preserve current visual behavior for unmatched or vacation-titled absences (`bg-info/30`).
+- Keep the classification a pure, testable frontend function with no backend changes.
+
+**Non-Goals:**
+- No iCal `CATEGORIES` property parsing or CalDAV/Zep upstream changes.
+- No user-configurable category/color mapping — the keyword-to-color table is a fixed constant for this change.
+- No changes to assignment or bare event coloring.
+
+## Decisions
+
+### Classification: keyword matching on title, frontend-only
+Add a pure function (e.g. `absenceCategoryColor(title: string): string`) in `src/app/types.ts` that case-insensitively matches known German substrings against the absence title and returns a Tailwind/DaisyUI class.
+Alternative considered: parsing iCal `CATEGORIES` in the Rust backend. Rejected per user decision — the upstream Zep/CalDAV source does not reliably set this field today, and title-based matching requires no backend or Zep changes.
+
+### Color mapping table
+| Keyword substrings (case-insensitive) | Category | Color class |
+|---|---|---|
+| `krank` | sick | `bg-error/30` |
+| `sonderurlaub`, `fortbildung`, `schulung` | special leave / training | `bg-accent/30` |
+| anything else (including `urlaub`) | vacation / other (default) | `bg-info/30` |
+
+Alternative considered: a distinct color per every conceivable absence reason. Rejected as YAGNI — only `error` and `accent` are free, unused semantic tokens; adding more categories would require non-semantic custom colors, which is unnecessary for the requested scope.
+
+### Spec/code alignment
+The existing `employee-absence-display` spec says absences use "a warning color"; the code has always used `bg-info/30`. This change updates the spec text to match actual category-derived behavior instead of leaving the stale "warning" wording.
+
+## Risks / Trade-offs
+
+- [Keyword matching misses unanticipated title phrasing] → Mitigate by keeping the default fallback identical to today's uniform color, so unmatched titles degrade to current behavior rather than breaking.
+- [Reusing `error` for sick absences could read as "something went wrong"] → Accepted trade-off given only 3 unused semantic tokens exist; documented here for future reviewers.
+
+## Migration Plan
+
+- Add the classifier function and wire it into `toCellEvent()`; no data migration needed since this is a pure rendering change.
+- Update the `employee-absence-display` spec delta and archive it alongside the code change.
+
+## Open Questions
+
+None — scope and approach were confirmed via user clarification before writing this design.

--- a/openspec/changes/color-coded-events/design.md
+++ b/openspec/changes/color-coded-events/design.md
@@ -2,49 +2,75 @@
 
 Absence event color is decided purely in the frontend, in `toCellEvent()` (`src/app/types.ts:39-55`), which currently assigns `bg-info/30` to every event with `kind === "absence"`.
 Absence titles come from the iCal `SUMMARY` field with no structured category data — the `CalendarEventKind` enum only distinguishes `Assignment | Bare | Absence`, and no VEVENT `CATEGORIES` property is parsed anywhere in the CalDAV integration.
-The user confirmed (via clarification) that classification should be based on keyword-matching the German title text, scoped to absence events only; assignment and bare event coloring are unaffected.
-Daylite project-status colors already occupy `secondary`, `success`, `neutral`, `warning`, and `primary` (`projectStatusToColor`, `src/app/types.ts:19-36`), so absence categories must pick from the remaining DaisyUI semantic tokens (`info`, `accent`, `error`) to avoid visually colliding with assignment cards in the same grid.
+The user confirmed the six real Zep absence codes: `UB` (paid vacation), `UU` (unpaid vacation), `KR` (sick), `Kro` (sick without pay), `SU` (special vacation), `FA` (time off in lieu) — and that classification is keyword-matching on the title, scoped to absence events only.
+The user also requires: any day where an absence and an appointment (assignment event) coincide for the same employee must be highlighted red, and otherwise each code needs a color, with similar colors for similar types.
+Daylite project-status colors already occupy the DaisyUI `secondary`, `success`, `neutral`, `warning`, and `primary` tokens (`projectStatusToColor`, `src/app/types.ts:19-36`), and `error` is reserved exclusively for the new conflict indicator, so it cannot double as a category color.
+`accent` and `info` are the only other existing DaisyUI tokens, but the app's built-in dark theme ("business") reassigns hues inconsistently between light and dark for several tokens — most notably `accent` is teal (hue ≈185) in the light "corporate" theme but orange (hue ≈36) in the dark "business" theme, dangerously close to `error`'s dark hue (≈30). Reusing `accent` for a category color would therefore risk visually colliding with the conflict-red indicator in dark mode. This rules out reusing any existing semantic token for absence categories beyond the current `info` fallback.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Distinguish common absence categories (sick, special/training, vacation/other) by color in the timetable.
-- Preserve current visual behavior for unmatched or vacation-titled absences (`bg-info/30`).
-- Keep the classification a pure, testable frontend function with no backend changes.
+- Give each of the six absence codes a color, with the three related pairs/groups sharing a hue at different intensities.
+- Reserve a red conflict indicator, paired with an icon and label (not color alone), for days where an absence and an appointment coincide.
+- Keep all category and conflict colors colorblind-safe and consistent across the light and dark themes.
+- Preserve current visual behavior (`bg-info/30`) for absence titles that don't match any known code.
 
 **Non-Goals:**
 - No iCal `CATEGORIES` property parsing or CalDAV/Zep upstream changes.
-- No user-configurable category/color mapping — the keyword-to-color table is a fixed constant for this change.
-- No changes to assignment or bare event coloring.
+- No user-configurable category/color mapping — the code-to-color table is a fixed constant for this change.
+- No changes to assignment (project-status) or bare event coloring.
 
 ## Decisions
 
-### Classification: keyword matching on title, frontend-only
-Add a pure function (e.g. `absenceCategoryColor(title: string): string`) in `src/app/types.ts` that case-insensitively matches known German substrings against the absence title and returns a Tailwind/DaisyUI class.
-Alternative considered: parsing iCal `CATEGORIES` in the Rust backend. Rejected per user decision — the upstream Zep/CalDAV source does not reliably set this field today, and title-based matching requires no backend or Zep changes.
+### Grouping the six codes into three hue families
+- **Vacation family** (`UB` paid, `SU` special, `UU` unpaid): all fundamentally vacation-leave, sharing one hue at three intensities.
+- **Sick family** (`KR`, `Kro`): both sickness-related, sharing a second hue at two intensities.
+- **Time off in lieu** (`FA`): a distinct concept (compensatory time, not vacation or sickness), gets its own third hue.
 
-### Color mapping table
-| Keyword substrings (case-insensitive) | Category | Color class |
-|---|---|---|
-| `krank` | sick | `bg-error/30` |
-| `sonderurlaub`, `fortbildung`, `schulung` | special leave / training | `bg-accent/30` |
-| anything else (including `urlaub`) | vacation / other (default) | `bg-info/30` |
+This groups exactly as the user described ("similar colors for similar types") while giving `FA` genuine distinctiveness rather than forcing it into an unrelated family.
 
-Alternative considered: a distinct color per every conceivable absence reason. Rejected as YAGNI — only `error` and `accent` are free, unused semantic tokens; adding more categories would require non-semantic custom colors, which is unnecessary for the requested scope.
+### Three new dedicated color tokens, not reused semantic tokens
+Add three new theme-level custom properties in `src/app.css`, defined once (not varying per light/dark theme, since all three values were validated to sit inside both the light and dark lightness bands):
 
-### Spec/code alignment
-The existing `employee-absence-display` spec says absences use "a warning color"; the code has always used `bg-info/30`. This change updates the spec text to match actual category-derived behavior instead of leaving the stale "warning" wording.
+| Token | Hue family | OKLCH | Approx. hex |
+|---|---|---|---|
+| `--color-absence-vacation` | indigo/violet | `oklch(51.1% 0.230 277)` | `#4f46e5` |
+| `--color-absence-special` | fuchsia/magenta | `oklch(59.1% 0.257 323)` | `#c026d3` |
+| `--color-absence-sick` | pink/rose-magenta | `oklch(65.6% 0.212 354)` | `#ec4899` |
+
+These were chosen and validated with the dataviz skill's `validate_palette.js` script against this app's actual light surface (`#ffffff`) and an approximation of its dark surface (`oklch(37% 0.013 285.805) ≈ #3f3f46`), alongside the existing `error` token (light `≈ #f0654a`, dark `≈ #c23b2e`) to confirm the conflict-red stays distinguishable:
+- Lightness band, chroma floor, and CVD (colorblind) separation all **PASS** in both modes for the three-family set plus `error`.
+- The `vacation` ↔ `special` pair sits in the CVD floor band (ΔE ≈ 12.4, just at the passing edge) and the dark-mode contrast ratios sit below the ideal 3:1 — both are acceptable under the skill's rules because every event card already shows its title as visible text (the "secondary encoding"/"relief" the skill requires when a palette only clears the floor band, not the full target).
+
+Alternative considered: reusing `accent`/`info` for two of the three groups to avoid adding new tokens. Rejected once the light/dark hue-reassignment problem above was found — `accent` cannot be trusted to keep the same visual identity across themes, and only one free token (`info`) remains, not enough for three groups.
+
+### Intensity mapping within a family (opacity, matching existing convention)
+Reuse the codebase's existing `bg-<token>/<opacity>` convention to encode intensity within a family, rather than defining six separate hex values:
+- `UB` → `bg-(--color-absence-vacation)/50`, `SU` → `bg-(--color-absence-vacation)/30`, `UU` → `bg-(--color-absence-vacation)/15`
+- `KR` → `bg-(--color-absence-sick)/40`, `Kro` → `bg-(--color-absence-sick)/20`
+- `FA` → `bg-(--color-absence-special)/30`
+- Unmatched → `bg-info/30` (unchanged default)
+
+### Code matching rule
+Match the absence title's leading token (split on whitespace/`-`/`:`) case-insensitively against the six codes, rather than a bare substring search — a naive "contains" check risks false positives for two-letter codes like `SU` appearing inside unrelated words. This assumption about Zep's title format (code as a leading token) should be verified against real title samples during implementation; if Zep formats titles differently, the matching rule is the only piece that needs adjusting.
+
+### Conflict indicator: status color, not a category
+When a cell contains both an absence event and an assignment (`kind === "assignment"`) event for the same employee/day, add a red conflict indicator — a `ring-2 ring-error` (or equivalent border) on the cell plus a small warning icon (Lucide) with a German tooltip/label (e.g. `"Termin während Abwesenheit"`), never color alone, per the dataviz skill's status-color rule that state (good/warning/critical) must never be encoded as "just another category color."
+Bare (non-assignment) events do not trigger the conflict indicator — only assignment events count as "an appointment" for this purpose.
 
 ## Risks / Trade-offs
 
-- [Keyword matching misses unanticipated title phrasing] → Mitigate by keeping the default fallback identical to today's uniform color, so unmatched titles degrade to current behavior rather than breaking.
-- [Reusing `error` for sick absences could read as "something went wrong"] → Accepted trade-off given only 3 unused semantic tokens exist; documented here for future reviewers.
+- [Code-matching assumption about title format is unverified against real Zep data] → Mitigate by isolating the matching rule behind a single function with test coverage that's easy to adjust if the real title format differs (e.g. code embedded rather than leading).
+- [`vacation` ↔ `special` CVD separation sits at the floor, not the full target] → Mitigated by the event title always being visible as text on the card (secondary encoding), per the skill's floor-band rule.
+- [Dark-surface contrast for the three new tokens sits below 3:1 at low opacity] → Accepted, same as the app's existing absence/status color usage (all applied as low-opacity washes with the title text as the readable channel, not the fill itself).
 
 ## Migration Plan
 
-- Add the classifier function and wire it into `toCellEvent()`; no data migration needed since this is a pure rendering change.
+- Add the three new CSS custom properties to `src/app.css` first (additive, no visual change yet).
+- Implement and test the code classifier and conflict detector in `src/app/types.ts`.
+- Wire the new colors and conflict indicator into `toCellEvent()`/`timetable-cell.tsx`.
 - Update the `employee-absence-display` spec delta and archive it alongside the code change.
 
 ## Open Questions
 
-None — scope and approach were confirmed via user clarification before writing this design.
+None — codes, grouping, and conflict-highlighting behavior were confirmed by the user before writing this design. The title-matching format (leading token vs. embedded) is a documented assumption to verify during implementation, not an open design question.

--- a/openspec/changes/color-coded-events/proposal.md
+++ b/openspec/changes/color-coded-events/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Absence events are currently all rendered with the same color (`bg-info/30`) regardless of the absence type, so users cannot tell vacation, sick leave, or special leave apart at a glance in the planning grid.
+Distinguishing absence categories by color makes the weekly view scannable without opening each event.
+
+## What Changes
+
+- Classify absence events into categories (vacation, sick, special/training, other) by keyword-matching the event's title (iCal `SUMMARY`), since no structured category data exists in CalDAV/Zep today.
+- Map each absence category to a distinct DaisyUI color class, reusing the existing `bg-<token>/30` styling convention, and avoiding colors already used for Daylite project status (`secondary`, `success`, `neutral`, `warning`, `primary`) to prevent visual ambiguity between assignment and absence cards.
+- Unmatched or vacation-titled absences keep the current `bg-info/30` color, so existing behavior is preserved for the common case.
+- Align the `employee-absence-display` spec wording with actual rendering behavior (the spec currently says "warning color" while the code uses `bg-info/30`).
+
+## Capabilities
+
+### Modified Capabilities
+- `employee-absence-display`: "Absence event display" requirement changes from a single uniform absence color to a category-derived color, based on keyword-matching the absence title.
+
+## Impact
+
+- `src/app/types.ts`: extend `toCellEvent`/color derivation with a title-based absence category classifier.
+- `openspec/specs/employee-absence-display/spec.md`: delta to the "Absence event display" requirement.
+- No backend (Rust) changes required — absence titles already arrive via `EmployeeWeekEvents.events[].title`, and category-to-color mapping is a pure frontend display concern, matching the existing `projectStatusToColor` pattern.
+- Tests: `bun test` coverage for the new classifier's keyword matches and fallback behavior.

--- a/openspec/changes/color-coded-events/proposal.md
+++ b/openspec/changes/color-coded-events/proposal.md
@@ -1,23 +1,29 @@
 ## Why
 
-Absence events are currently all rendered with the same color (`bg-info/30`) regardless of the absence type, so users cannot tell vacation, sick leave, or special leave apart at a glance in the planning grid.
-Distinguishing absence categories by color makes the weekly view scannable without opening each event.
+Absence events are currently all rendered with the same color (`bg-info/30`) regardless of the absence type, so users cannot tell paid vacation, sick leave, or special leave apart at a glance in the planning grid.
+Distinguishing absence categories by color makes the weekly view scannable without opening each event, and flagging a day where an appointment collides with an absence surfaces a scheduling conflict that currently has no visual signal at all.
 
 ## What Changes
 
-- Classify absence events into categories (vacation, sick, special/training, other) by keyword-matching the event's title (iCal `SUMMARY`), since no structured category data exists in CalDAV/Zep today.
-- Map each absence category to a distinct DaisyUI color class, reusing the existing `bg-<token>/30` styling convention, and avoiding colors already used for Daylite project status (`secondary`, `success`, `neutral`, `warning`, `primary`) to prevent visual ambiguity between assignment and absence cards.
-- Unmatched or vacation-titled absences keep the current `bg-info/30` color, so existing behavior is preserved for the common case.
+- Classify absence events into the six known Zep absence codes by keyword-matching the event's title (iCal `SUMMARY`): `UB` (paid vacation), `UU` (unpaid vacation), `KR` (sick), `Kro` (sick without pay), `SU` (special vacation), `FA` (time off in lieu).
+- Group related codes under the same color hue at different intensities, and give unrelated codes their own hue:
+  - Vacation family (`UB`, `SU`, `UU`) shares one hue at decreasing intensity.
+  - Sick family (`KR`, `Kro`) shares a second hue at decreasing intensity.
+  - `FA` (time off in lieu) is not vacation- or sickness-related, so it gets its own third hue.
+- Add three new theme-level color tokens for these hues, validated for colorblind-safe separation from each other and from the existing Daylite project-status colors and the reserved conflict color (see design.md); unmatched/unrecognized absence titles keep the current `bg-info/30` color.
+- Highlight any day where an absence event and an appointment (assignment event) occur together for the same employee with a red conflict indicator, paired with an icon and a German label (not color alone), since a scheduling conflict is a status, not a category.
 - Align the `employee-absence-display` spec wording with actual rendering behavior (the spec currently says "warning color" while the code uses `bg-info/30`).
 
 ## Capabilities
 
 ### Modified Capabilities
-- `employee-absence-display`: "Absence event display" requirement changes from a single uniform absence color to a category-derived color, based on keyword-matching the absence title.
+- `employee-absence-display`: "Absence event display" requirement changes from a single uniform absence color to a category-derived color per absence code, and gains a new conflict-highlighting requirement for days with both an absence and an appointment.
 
 ## Impact
 
-- `src/app/types.ts`: extend `toCellEvent`/color derivation with a title-based absence category classifier.
+- `src/app.css`: add three new theme-level custom color properties for the vacation, sick, and time-off-in-lieu hues (validated with the dataviz skill's palette checks).
+- `src/app/types.ts`: extend `toCellEvent`/color derivation with a title-based absence category classifier covering all six codes, plus conflict detection when an absence and an assignment share a cell.
+- `src/app/components/timetable-cell.tsx`: render the conflict indicator (icon + German label) when a cell is flagged as conflicting.
 - `openspec/specs/employee-absence-display/spec.md`: delta to the "Absence event display" requirement.
-- No backend (Rust) changes required — absence titles already arrive via `EmployeeWeekEvents.events[].title`, and category-to-color mapping is a pure frontend display concern, matching the existing `projectStatusToColor` pattern.
-- Tests: `bun test` coverage for the new classifier's keyword matches and fallback behavior.
+- No backend (Rust) changes required — absence titles already arrive via `EmployeeWeekEvents.events[].title`, and category-to-color mapping and conflict detection are pure frontend display concerns, matching the existing `projectStatusToColor` pattern.
+- Tests: `bun test` coverage for the classifier's code matches, the fallback, and conflict detection.

--- a/openspec/changes/color-coded-events/specs/employee-absence-display/spec.md
+++ b/openspec/changes/color-coded-events/specs/employee-absence-display/spec.md
@@ -34,14 +34,14 @@ The system SHALL highlight a timetable cell in red, with an icon and German labe
 
 #### Scenario: Absence and appointment coincide
 - **WHEN** a timetable cell contains both an absence event and an assignment event for the same employee and day
-- **THEN** the cell shows a red conflict indicator
-- **AND** the indicator includes an icon and a German label explaining the conflict
+- **THEN** the cell shows a red conflict indicator icon
 - **AND** the absence and assignment events keep their own category/status colors alongside the indicator
 
 #### Scenario: Absence without an appointment
 - **WHEN** a timetable cell contains an absence event and no assignment event
 - **THEN** no conflict indicator is shown
 
-#### Scenario: Bare event does not trigger a conflict
+#### Scenario: Bare event triggers a conflict
 - **WHEN** a timetable cell contains an absence event and a bare (non-assignment) event
-- **THEN** no conflict indicator is shown
+- **THEN** the cell shows a red conflict indicator icon
+- **AND** the absence and assignment events keep their own category/status colors alongside the indicator

--- a/openspec/changes/color-coded-events/specs/employee-absence-display/spec.md
+++ b/openspec/changes/color-coded-events/specs/employee-absence-display/spec.md
@@ -1,26 +1,47 @@
 ## MODIFIED Requirements
 
 ### Requirement: Absence event display
-The system SHALL render absence events visually distinct from assignment and bare events in the timetable, using a color derived from the absence category.
+The system SHALL render absence events visually distinct from assignment and bare events in the timetable, using a color derived from the absence code.
 
 #### Scenario: Absence cell styling
 - **WHEN** a timetable cell contains an absence event
 - **THEN** the absence event is rendered non-interactively (no button)
-- **AND** it uses a color derived from its absence category, distinct from assignment and bare event colors
+- **AND** it uses a color derived from its absence code, distinct from assignment and bare event colors
 
-#### Scenario: Sick absence category
-- **WHEN** an absence event's title contains "krank" (case-insensitive)
-- **THEN** the absence event uses the sick category color (`bg-error/30`)
+#### Scenario: Vacation family codes
+- **WHEN** an absence event's title's leading code is `UB`, `SU`, or `UU` (case-insensitive)
+- **THEN** the absence event uses the vacation hue, at a distinct intensity per code (`UB` strongest, `SU` medium, `UU` lightest)
 
-#### Scenario: Special leave or training absence category
-- **WHEN** an absence event's title contains "sonderurlaub", "fortbildung", or "schulung" (case-insensitive)
-- **THEN** the absence event uses the special leave/training category color (`bg-accent/30`)
+#### Scenario: Sick family codes
+- **WHEN** an absence event's title's leading code is `KR` or `Kro` (case-insensitive)
+- **THEN** the absence event uses the sick hue, at a distinct intensity per code (`KR` stronger, `Kro` lighter)
 
-#### Scenario: Vacation or unmatched absence category
-- **WHEN** an absence event's title does not match any known category keyword
+#### Scenario: Time off in lieu code
+- **WHEN** an absence event's title's leading code is `FA` (case-insensitive)
+- **THEN** the absence event uses its own distinct hue, separate from the vacation and sick hues
+
+#### Scenario: Unmatched absence code
+- **WHEN** an absence event's title does not match any known code
 - **THEN** the absence event uses the default absence color (`bg-info/30`)
 
 #### Scenario: Multiple event types in same cell
 - **WHEN** a cell contains both an absence event and an assignment event
 - **THEN** both are rendered in the cell
 - **AND** each uses its respective styling
+
+### Requirement: Absence and appointment conflict indicator
+The system SHALL highlight a timetable cell in red, with an icon and German label, when it contains both an absence event and an assignment event for the same employee and day.
+
+#### Scenario: Absence and appointment coincide
+- **WHEN** a timetable cell contains both an absence event and an assignment event for the same employee and day
+- **THEN** the cell shows a red conflict indicator
+- **AND** the indicator includes an icon and a German label explaining the conflict
+- **AND** the absence and assignment events keep their own category/status colors alongside the indicator
+
+#### Scenario: Absence without an appointment
+- **WHEN** a timetable cell contains an absence event and no assignment event
+- **THEN** no conflict indicator is shown
+
+#### Scenario: Bare event does not trigger a conflict
+- **WHEN** a timetable cell contains an absence event and a bare (non-assignment) event
+- **THEN** no conflict indicator is shown

--- a/openspec/changes/color-coded-events/specs/employee-absence-display/spec.md
+++ b/openspec/changes/color-coded-events/specs/employee-absence-display/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Absence event display
+The system SHALL render absence events visually distinct from assignment and bare events in the timetable, using a color derived from the absence category.
+
+#### Scenario: Absence cell styling
+- **WHEN** a timetable cell contains an absence event
+- **THEN** the absence event is rendered non-interactively (no button)
+- **AND** it uses a color derived from its absence category, distinct from assignment and bare event colors
+
+#### Scenario: Sick absence category
+- **WHEN** an absence event's title contains "krank" (case-insensitive)
+- **THEN** the absence event uses the sick category color (`bg-error/30`)
+
+#### Scenario: Special leave or training absence category
+- **WHEN** an absence event's title contains "sonderurlaub", "fortbildung", or "schulung" (case-insensitive)
+- **THEN** the absence event uses the special leave/training category color (`bg-accent/30`)
+
+#### Scenario: Vacation or unmatched absence category
+- **WHEN** an absence event's title does not match any known category keyword
+- **THEN** the absence event uses the default absence color (`bg-info/30`)
+
+#### Scenario: Multiple event types in same cell
+- **WHEN** a cell contains both an absence event and an assignment event
+- **THEN** both are rendered in the cell
+- **AND** each uses its respective styling

--- a/openspec/changes/color-coded-events/tasks.md
+++ b/openspec/changes/color-coded-events/tasks.md
@@ -2,24 +2,13 @@
 
 - [ ] 1.1 Add `--color-absence-vacation` (`oklch(51.1% 0.230 277)`), `--color-absence-special` (`oklch(59.1% 0.257 323)`), and `--color-absence-sick` (`oklch(65.6% 0.212 354)`) as new custom properties in `src/app.css`
 
-## 2. Absence code classifier
+## 2. Conflict detection
 
-- [ ] 2.1 Write failing `bun test`s for an `absenceCategoryColor(title)` function: leading-token match (case-insensitive) for `UB`, `SU`, `UU` → vacation hue at 3 intensities; `KR`, `Kro` → sick hue at 2 intensities; `FA` → special hue; unmatched → `bg-info/30`
-- [ ] 2.2 Implement `absenceCategoryColor` in `src/app/types.ts`, satisfying the tests
+- [ ] 2.1 Write failing `bun test`s for a conflict detector: cell with absence + assignment event for the same employee/day → conflict; absence + bare event → conflict; absence alone → no conflict
+- [ ] 2.2 Implement the conflict detector, satisfying the tests
 
-## 3. Conflict detection
+## 3. Wire into rendering
 
-- [ ] 3.1 Write failing `bun test`s for a conflict detector: cell with absence + assignment event for the same employee/day → conflict; absence + bare event → no conflict; absence alone → no conflict
-- [ ] 3.2 Implement the conflict detector, satisfying the tests
-
-## 4. Wire into rendering
-
-- [ ] 4.1 Update `toCellEvent()` in `src/app/types.ts` to call `absenceCategoryColor(event.title)` for `kind === "absence"` instead of the hardcoded `bg-info/30`
-- [ ] 4.2 Update `src/app/components/timetable-cell.tsx` to render a red conflict indicator (ring/border + Lucide warning icon + German label, e.g. "Termin während Abwesenheit") when the conflict detector flags a cell
-- [ ] 4.3 Add/update `bun test` coverage for `toCellEvent()` producing the correct color per absence code, and for the conflict indicator rendering only when flagged
-
-## 5. Spec and verification
-
-- [ ] 5.1 Run `bun test` and confirm all new and existing tests pass
-- [ ] 5.2 Run `bun lint` and fix any issues
-- [ ] 5.3 Manually verify in the running app: each absence code (`UB`, `UU`, `KR`, `Kro`, `SU`, `FA`) shows its expected color in both light and dark theme, and a day with both an absence and an appointment shows the red conflict indicator
+- [ ] 3.1 Update `toCellEvent()` in `src/app/types.ts` to call `absenceCategoryColor(event.title)` for `kind === "absence"` instead of the hardcoded `bg-info/30`
+- [ ] 3.2 Update `src/app/components/timetable-cell.tsx` to render a red conflict indicator (ring/border + Lucide warning icon) when the conflict detector flags a cell
+- [ ] 3.3 Add/update `bun test` coverage for `toCellEvent()` producing the correct color per absence code, and for the conflict indicator rendering only when flagged

--- a/openspec/changes/color-coded-events/tasks.md
+++ b/openspec/changes/color-coded-events/tasks.md
@@ -1,15 +1,25 @@
-## 1. Absence category classifier
+## 1. Theme colors
 
-- [ ] 1.1 Write failing `bun test`s for an `absenceCategoryColor(title)` function: "krank" → `bg-error/30`, "sonderurlaub"/"fortbildung"/"schulung" → `bg-accent/30`, unmatched/vacation → `bg-info/30`, case-insensitive matching
-- [ ] 1.2 Implement `absenceCategoryColor` in `src/app/types.ts`, satisfying the tests
+- [ ] 1.1 Add `--color-absence-vacation` (`oklch(51.1% 0.230 277)`), `--color-absence-special` (`oklch(59.1% 0.257 323)`), and `--color-absence-sick` (`oklch(65.6% 0.212 354)`) as new custom properties in `src/app.css`
 
-## 2. Wire classifier into rendering
+## 2. Absence code classifier
 
-- [ ] 2.1 Update `toCellEvent()` in `src/app/types.ts` to call `absenceCategoryColor(event.title)` for `kind === "absence"` instead of the hardcoded `bg-info/30`
-- [ ] 2.2 Add/update `bun test` coverage for `toCellEvent()` producing the correct color per absence category
+- [ ] 2.1 Write failing `bun test`s for an `absenceCategoryColor(title)` function: leading-token match (case-insensitive) for `UB`, `SU`, `UU` → vacation hue at 3 intensities; `KR`, `Kro` → sick hue at 2 intensities; `FA` → special hue; unmatched → `bg-info/30`
+- [ ] 2.2 Implement `absenceCategoryColor` in `src/app/types.ts`, satisfying the tests
 
-## 3. Spec and verification
+## 3. Conflict detection
 
-- [ ] 3.1 Run `bun test` and confirm all new and existing tests pass
-- [ ] 3.2 Run `bun lint` and fix any issues
-- [ ] 3.3 Manually verify in the running app: absence events with different titles (e.g. "Urlaub", "Krankheit", "Fortbildung") show visually distinct colors in the planning grid
+- [ ] 3.1 Write failing `bun test`s for a conflict detector: cell with absence + assignment event for the same employee/day → conflict; absence + bare event → no conflict; absence alone → no conflict
+- [ ] 3.2 Implement the conflict detector, satisfying the tests
+
+## 4. Wire into rendering
+
+- [ ] 4.1 Update `toCellEvent()` in `src/app/types.ts` to call `absenceCategoryColor(event.title)` for `kind === "absence"` instead of the hardcoded `bg-info/30`
+- [ ] 4.2 Update `src/app/components/timetable-cell.tsx` to render a red conflict indicator (ring/border + Lucide warning icon + German label, e.g. "Termin während Abwesenheit") when the conflict detector flags a cell
+- [ ] 4.3 Add/update `bun test` coverage for `toCellEvent()` producing the correct color per absence code, and for the conflict indicator rendering only when flagged
+
+## 5. Spec and verification
+
+- [ ] 5.1 Run `bun test` and confirm all new and existing tests pass
+- [ ] 5.2 Run `bun lint` and fix any issues
+- [ ] 5.3 Manually verify in the running app: each absence code (`UB`, `UU`, `KR`, `Kro`, `SU`, `FA`) shows its expected color in both light and dark theme, and a day with both an absence and an appointment shows the red conflict indicator

--- a/openspec/changes/color-coded-events/tasks.md
+++ b/openspec/changes/color-coded-events/tasks.md
@@ -1,0 +1,15 @@
+## 1. Absence category classifier
+
+- [ ] 1.1 Write failing `bun test`s for an `absenceCategoryColor(title)` function: "krank" → `bg-error/30`, "sonderurlaub"/"fortbildung"/"schulung" → `bg-accent/30`, unmatched/vacation → `bg-info/30`, case-insensitive matching
+- [ ] 1.2 Implement `absenceCategoryColor` in `src/app/types.ts`, satisfying the tests
+
+## 2. Wire classifier into rendering
+
+- [ ] 2.1 Update `toCellEvent()` in `src/app/types.ts` to call `absenceCategoryColor(event.title)` for `kind === "absence"` instead of the hardcoded `bg-info/30`
+- [ ] 2.2 Add/update `bun test` coverage for `toCellEvent()` producing the correct color per absence category
+
+## 3. Spec and verification
+
+- [ ] 3.1 Run `bun test` and confirm all new and existing tests pass
+- [ ] 3.2 Run `bun lint` and fix any issues
+- [ ] 3.3 Manually verify in the running app: absence events with different titles (e.g. "Urlaub", "Krankheit", "Fortbildung") show visually distinct colors in the planning grid

--- a/openspec/changes/prevent-fixed-appointment-modification/.openspec.yaml
+++ b/openspec/changes/prevent-fixed-appointment-modification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/prevent-fixed-appointment-modification/design.md
+++ b/openspec/changes/prevent-fixed-appointment-modification/design.md
@@ -1,0 +1,59 @@
+## Context
+
+Daylite projects carry a `category: Option<String>` field (`src-tauri/src/integrations/daylite/projects.rs:23-26,50-53,83-86`), already used for filtering (`OVERDUE_CATEGORY = "Überfällig"`, lines 115-122).
+Assignment write commands live in `src-tauri/src/integrations/calendar/commands.rs`: `create_assignment(app, employee_reference, date, project_ref, project_name)`, `update_assignment(app, href, uid, date, project_ref, project_name)`, and `delete_assignment(app, href)`.
+Critically, `update_assignment` receives the *new/target* `project_ref` as a parameter, not the event's *current* one, and `delete_assignment` receives only `href` — neither command has the current project linkage available without a fetch.
+`fetch_project_by_reference` (`daylite/projects.rs:411-437`) already fetches a single project by reference but discards `category`, returning only `(name, status)`.
+The `daylite:/<path>` reference is parsed from an event's DESCRIPTION inside `classify_event` (`calendar/events.rs:12-58`), which operates on a fully-parsed `RawVEvent`, not a bare description string.
+The existing "Absence calendar is never written" guard (`ical-assignment-sync` spec, enforced via `targets_absence_calendar` in `caldav.rs:141-147`) is the closest precedent for a pre-write rejection with a German error message.
+The user confirmed the category source is the Daylite project the event is linked to (not an iCal field), and that enforcement must be a backend guard (not just a UI affordance), so a modified frontend cannot bypass it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reject `update_assignment` and `delete_assignment` before any CalDAV write when the event's linked Daylite project has category `"Termin FIX geplant"`.
+- Make the guard authoritative: derive the current project link from the event itself (via CalDAV), not from a client-supplied parameter.
+- Give the user an immediate, non-error-feeling UI cue (disabled controls) in the common case, with the backend guard as the enforcement backstop.
+
+**Non-Goals:**
+- No change to `create_assignment` — creating new assignments is not restricted by this change.
+- No configurable/multi-category protection list — a single fixed category string for this change (YAGNI; extend later if more categories need protection).
+- No caching of the protection check result — each update/delete re-derives it fresh, since staleness here has real consequences (accidentally allowing a write that should be blocked).
+
+## Decisions
+
+### Guard fetches the event fresh rather than trusting a client-supplied project ref
+`update_assignment`/`delete_assignment` will issue a CalDAV GET on `href` to read the event's current DESCRIPTION, parse the `daylite:/<path>` reference, and look up that project's category — before performing the PUT/DELETE.
+Alternative considered: have the frontend pass the currently-known `project_ref` (already visible in the modal) as a parameter for the backend to check. Rejected because the user explicitly required a guard that "cannot be bypassed by a modified frontend" — trusting a client-supplied value would defeat that.
+
+### Extract description-parsing into a reusable function
+Pull the `daylite:` prefix-stripping logic out of `classify_event` (`events.rs:12-58`) into a standalone function operating on a bare description string, callable both from event classification and from the new guard.
+Alternative considered: duplicate the parsing logic in the guard. Rejected as unnecessary duplication once extraction is straightforward.
+
+### Extend `fetch_project_by_reference` to return category
+Change its return type from `(name, status)` to include `category`, updating the one existing call site in `load_week_events` to ignore the new field.
+Alternative considered: add a separate `fetch_project_category_by_reference` function. Rejected — it would duplicate the same HTTP call `fetch_project_by_reference` already makes for the same project.
+
+### Frontend disables affordances using the already-cached project category
+The assignment modal already resolves the linked project via the Daylite project cache (`daylite-projects.ts`) for status/color; that cached `PlanningProjectRecord` already includes `category`. Disable edit/delete controls when `category === "Termin FIX geplant"`, with a German explanatory notice.
+This is advisory only — the backend guard is the actual enforcement, since the cache could be stale or the category could differ from what the backend independently determines.
+
+### Error convention
+Reuse the "Absence calendar is never written" pattern: reject before the network write, return a German message, e.g. `"Dieser Termin ist als 'Termin FIX geplant' gesperrt und kann nicht geändert oder gelöscht werden."`
+
+## Risks / Trade-offs
+
+- [Guard adds a CalDAV GET before every update/delete] → Accepted trade-off: correctness (cannot be bypassed) outweighs one extra round-trip on a low-frequency write path; the recently-proposed CalDAV event cache (see `caldav-caching-improvements`) may serve this GET from cache once implemented.
+- [Frontend cache and backend guard could disagree if the category changes between page load and save] → Mitigate by making the backend guard authoritative and always re-derived fresh; the frontend disabled-state is just a UX hint.
+- [Deleting a protected event that no longer resolves its project reference (e.g. project renamed/removed in Daylite)] → If the project lookup fails, treat as unprotected (fail open) so a broken Daylite link does not permanently lock an event; log the lookup failure for visibility.
+
+## Migration Plan
+
+- Implement the extracted parser and extended `fetch_project_by_reference` first (backwards compatible, additive).
+- Wire the guard into `update_assignment`/`delete_assignment` behind `cargo test` coverage (red/green TDD).
+- Wire the frontend disabled-state after the backend guard exists, so manual testing has the real rejection message to display when reached via a stale UI state.
+- No data migration required; this is a behavior-only change.
+
+## Open Questions
+
+None — scope and enforcement approach were confirmed via user clarification before writing this design.

--- a/openspec/changes/prevent-fixed-appointment-modification/design.md
+++ b/openspec/changes/prevent-fixed-appointment-modification/design.md
@@ -24,18 +24,22 @@ The user confirmed the category source is the Daylite project the event is linke
 
 ### Guard fetches the event fresh rather than trusting a client-supplied project ref
 `update_assignment`/`delete_assignment` will issue a CalDAV GET on `href` to read the event's current DESCRIPTION, parse the `daylite:/<path>` reference, and look up that project's category — before performing the PUT/DELETE.
-Alternative considered: have the frontend pass the currently-known `project_ref` (already visible in the modal) as a parameter for the backend to check. Rejected because the user explicitly required a guard that "cannot be bypassed by a modified frontend" — trusting a client-supplied value would defeat that.
+Alternative considered: have the frontend pass the currently-known `project_ref` (already visible in the modal) as a parameter for the backend to check.
+Rejected because the user explicitly required a guard that "cannot be bypassed by a modified frontend" — trusting a client-supplied value would defeat that.
 
 ### Extract description-parsing into a reusable function
 Pull the `daylite:` prefix-stripping logic out of `classify_event` (`events.rs:12-58`) into a standalone function operating on a bare description string, callable both from event classification and from the new guard.
-Alternative considered: duplicate the parsing logic in the guard. Rejected as unnecessary duplication once extraction is straightforward.
+Alternative considered: duplicate the parsing logic in the guard.
+Rejected as unnecessary duplication once extraction is straightforward.
 
 ### Extend `fetch_project_by_reference` to return category
 Change its return type from `(name, status)` to include `category`, updating the one existing call site in `load_week_events` to ignore the new field.
-Alternative considered: add a separate `fetch_project_category_by_reference` function. Rejected — it would duplicate the same HTTP call `fetch_project_by_reference` already makes for the same project.
+Alternative considered: add a separate `fetch_project_category_by_reference` function.
+Rejected — it would duplicate the same HTTP call `fetch_project_by_reference` already makes for the same project.
 
 ### Frontend disables affordances using the already-cached project category
-The assignment modal already resolves the linked project via the Daylite project cache (`daylite-projects.ts`) for status/color; that cached `PlanningProjectRecord` already includes `category`. Disable edit/delete controls when `category === "Termin FIX geplant"`, with a German explanatory notice.
+The assignment modal already resolves the linked project via the Daylite project cache (`daylite-projects.ts`) for status/color; that cached `PlanningProjectRecord` already includes `category`.
+Disable edit/delete controls when `category === "Termin FIX geplant"`, with a German explanatory notice.
 This is advisory only — the backend guard is the actual enforcement, since the cache could be stale or the category could differ from what the backend independently determines.
 
 ### Error convention

--- a/openspec/changes/prevent-fixed-appointment-modification/design.md
+++ b/openspec/changes/prevent-fixed-appointment-modification/design.md
@@ -49,7 +49,7 @@ Reuse the "Absence calendar is never written" pattern: reject before the network
 
 - [Guard adds a CalDAV GET before every update/delete] → Accepted trade-off: correctness (cannot be bypassed) outweighs one extra round-trip on a low-frequency write path; the recently-proposed CalDAV event cache (see `caldav-caching-improvements`) may serve this GET from cache once implemented.
 - [Frontend cache and backend guard could disagree if the category changes between page load and save] → Mitigate by making the backend guard authoritative and always re-derived fresh; the frontend disabled-state is just a UX hint.
-- [Deleting a protected event that no longer resolves its project reference (e.g. project renamed/removed in Daylite)] → If the project lookup fails, treat as unprotected (fail open) so a broken Daylite link does not permanently lock an event; log the lookup failure for visibility.
+- [Deleting a protected event that no longer resolves its project reference (e.g. project renamed/removed in Daylite)] → If the project lookup fails, treat as unprotected (fail open) so a broken Daylite link does not permanently lock an event; the user sees very obvious warnings so any changes are made knowing the risks.
 
 ## Migration Plan
 

--- a/openspec/changes/prevent-fixed-appointment-modification/proposal.md
+++ b/openspec/changes/prevent-fixed-appointment-modification/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Some CalDAV calendar entries are linked to Daylite projects that carry the category "Termin FIX geplant" (a fixed, already-confirmed appointment).
+These must not be accidentally moved, retitled, or deleted from the planning grid, since doing so would silently break a commitment already made outside the app.
+
+## What Changes
+
+- Add a backend guard that rejects `update_assignment` and `delete_assignment` for any event linked to a Daylite project whose `category` is `"Termin FIX geplant"`, before the CalDAV write is issued.
+- The guard determines the event's current linked project by fetching the event via its `href` and parsing the `daylite:/<path>` reference from its DESCRIPTION, then looking up that project's category via the Daylite API — it does not trust a client-supplied project reference, so it cannot be bypassed by the frontend.
+- Extend the Daylite single-project lookup to also return `category` (it currently discards it).
+- Disable the edit and delete affordances in the assignment modal when the currently loaded assignment's project category is `"Termin FIX geplant"` (using the category already available in the frontend's Daylite project cache), and show a German explanation instead of the usual controls.
+- If a write is attempted anyway (e.g. a stale UI state) and the backend rejects it, show the German error message returned by the backend.
+- `create_assignment` is unaffected — this only protects existing fixed appointments from being changed or removed.
+
+## Capabilities
+
+### New Capabilities
+- `fixed-appointment-protection`: Backend guard that identifies events linked to a Daylite project with category "Termin FIX geplant" and rejects modification/deletion of those events.
+
+### Modified Capabilities
+- `ical-assignment-sync`: "Update assignment in CalDAV" and "Delete assignment from CalDAV" requirements gain a precondition that the operation is rejected when the target event is protected.
+- `assignment-modal-crud`: "Edit existing assignment" and "Delete assignment" requirements gain a precondition that edit/delete affordances are disabled for protected assignments, with a German explanation shown instead.
+
+## Impact
+
+- `src-tauri/src/integrations/daylite/projects.rs`: extend `fetch_project_by_reference` (or add a sibling) to return `category` alongside name/status; add a `FIXED_APPOINTMENT_CATEGORY` constant alongside the existing `OVERDUE_CATEGORY`.
+- `src-tauri/src/integrations/calendar/commands.rs`: `update_assignment` and `delete_assignment` fetch the current event (GET by `href`), parse its Daylite project reference, look up the project's category, and reject with a German error before issuing the CalDAV write.
+- `src-tauri/src/integrations/calendar/events.rs`: extract the existing `daylite:/<path>` DESCRIPTION-parsing logic into a function reusable outside of full event classification, so the guard can call it directly on a freshly-fetched description.
+- `src/app/components/assignment-modal.tsx`: disable edit/delete controls and show a German notice when the loaded assignment's project category is `"Termin FIX geplant"`.
+- Tests: `cargo test` coverage for the guard (protected/unprotected/lookup-failure cases); `bun test` coverage for the modal's disabled state.

--- a/openspec/changes/prevent-fixed-appointment-modification/specs/assignment-modal-crud/spec.md
+++ b/openspec/changes/prevent-fixed-appointment-modification/specs/assignment-modal-crud/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Edit existing assignment
+The system SHALL allow editing an existing assignment, unless it is protected because its linked Daylite project has category `"Termin FIX geplant"`.
+
+#### Scenario: Change project
+- **WHEN** user changes the project in edit mode and saves a non-protected assignment
+- **THEN** assignment is updated
+- **AND** grid reflects change immediately
+
+#### Scenario: Edit controls disabled for protected assignment
+- **WHEN** modal opens in edit mode for an assignment whose linked project has category `"Termin FIX geplant"`
+- **THEN** the save control is disabled
+- **AND** a German notice explains the appointment is fixed and cannot be edited
+
+#### Scenario: Backend rejects a stale edit attempt
+- **WHEN** a save is submitted for an assignment that the backend determines is protected
+- **THEN** the German error message returned by the backend is shown
+- **AND** the assignment is not modified
+
+### Requirement: Delete assignment
+The system SHALL allow removing an assignment, unless it is protected because its linked Daylite project has category `"Termin FIX geplant"`.
+
+#### Scenario: Delete assignment
+- **WHEN** user clicks delete and confirms for a non-protected assignment
+- **THEN** assignment is removed
+- **AND** grid updates to show empty cell
+
+#### Scenario: Delete control disabled for protected assignment
+- **WHEN** modal opens in edit mode for an assignment whose linked project has category `"Termin FIX geplant"`
+- **THEN** the delete control is disabled
+- **AND** a German notice explains the appointment is fixed and cannot be removed
+
+#### Scenario: Backend rejects a stale delete attempt
+- **WHEN** a delete is submitted for an assignment that the backend determines is protected
+- **THEN** the German error message returned by the backend is shown
+- **AND** the assignment is not removed

--- a/openspec/changes/prevent-fixed-appointment-modification/specs/fixed-appointment-protection/spec.md
+++ b/openspec/changes/prevent-fixed-appointment-modification/specs/fixed-appointment-protection/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Identify protected events by Daylite project category
+The system SHALL identify a CalDAV event as protected when the Daylite project it references has category `"Termin FIX geplant"`.
+
+#### Scenario: Event linked to protected category
+- **WHEN** an event's DESCRIPTION contains a `daylite:/<path>` reference
+- **AND** the referenced Daylite project's `category` is `"Termin FIX geplant"`
+- **THEN** the event is treated as protected
+
+#### Scenario: Event linked to non-protected category
+- **WHEN** an event's DESCRIPTION contains a `daylite:/<path>` reference
+- **AND** the referenced Daylite project's `category` is not `"Termin FIX geplant"` (including `null`)
+- **THEN** the event is not treated as protected
+
+#### Scenario: Event has no Daylite project reference
+- **WHEN** an event's DESCRIPTION contains no `daylite:/<path>` reference
+- **THEN** the event is not treated as protected
+
+#### Scenario: Project lookup fails
+- **WHEN** the Daylite project referenced by an event cannot be resolved (network error, project not found)
+- **THEN** the event is treated as not protected
+- **AND** the lookup failure is logged
+
+### Requirement: Reject modification of protected events
+The system SHALL reject `update_assignment` for a protected event before issuing any CalDAV write.
+
+#### Scenario: Update rejected for protected event
+- **WHEN** `update_assignment` is called for an event that is protected
+- **THEN** the operation is rejected before any CalDAV PUT request
+- **AND** a German error message explains the event is fixed and cannot be changed
+
+#### Scenario: Update allowed for non-protected event
+- **WHEN** `update_assignment` is called for an event that is not protected
+- **THEN** the CalDAV PUT proceeds as normal
+
+### Requirement: Reject deletion of protected events
+The system SHALL reject `delete_assignment` for a protected event before issuing any CalDAV write.
+
+#### Scenario: Delete rejected for protected event
+- **WHEN** `delete_assignment` is called for an event that is protected
+- **THEN** the operation is rejected before any CalDAV DELETE request
+- **AND** a German error message explains the event is fixed and cannot be removed
+
+#### Scenario: Delete allowed for non-protected event
+- **WHEN** `delete_assignment` is called for an event that is not protected
+- **THEN** the CalDAV DELETE proceeds as normal

--- a/openspec/changes/prevent-fixed-appointment-modification/specs/fixed-appointment-protection/spec.md
+++ b/openspec/changes/prevent-fixed-appointment-modification/specs/fixed-appointment-protection/spec.md
@@ -14,12 +14,14 @@ The system SHALL identify a CalDAV event as protected when the Daylite project i
 - **THEN** the event is not treated as protected
 
 #### Scenario: Event has no Daylite project reference
-- **WHEN** an event's DESCRIPTION contains no `daylite:/<path>` reference
-- **THEN** the event is not treated as protected
+- **WHEN** an event's DESCRIPTION contains no `daylite:/<path>` reference (bare event)
+- **THEN** the event is protected
 
 #### Scenario: Project lookup fails
 - **WHEN** the Daylite project referenced by an event cannot be resolved (network error, project not found)
 - **THEN** the event is treated as not protected
+- **AND** a warning message is shown to the user
+- **AND** the event has a warning icon
 - **AND** the lookup failure is logged
 
 ### Requirement: Reject modification of protected events

--- a/openspec/changes/prevent-fixed-appointment-modification/specs/ical-assignment-sync/spec.md
+++ b/openspec/changes/prevent-fixed-appointment-modification/specs/ical-assignment-sync/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Update assignment in CalDAV
+The system SHALL update an existing VEVENT when an assignment is modified, unless the event is protected (see `fixed-appointment-protection`).
+
+#### Scenario: Update assignment triggers CalDAV PUT
+- **WHEN** an existing, non-protected assignment is modified
+- **THEN** the existing VEVENT is updated via PUT using the stable UID
+- **AND** the UID does not change
+- **AND** repeated updates produce exactly one event
+
+#### Scenario: Update blocked for protected assignment
+- **WHEN** an update is attempted on an assignment whose linked Daylite project has category `"Termin FIX geplant"`
+- **THEN** the update is rejected before any CalDAV PUT request
+- **AND** a German error message is returned
+
+### Requirement: Delete assignment from CalDAV
+The system SHALL remove a VEVENT when an assignment is deleted, unless the event is protected (see `fixed-appointment-protection`).
+
+#### Scenario: Delete assignment triggers CalDAV DELETE
+- **WHEN** a non-protected assignment is deleted
+- **THEN** the corresponding VEVENT is removed from CalDAV
+- **AND** the operation is idempotent (no error if the event is already absent)
+
+#### Scenario: Delete blocked for protected assignment
+- **WHEN** a delete is attempted on an assignment whose linked Daylite project has category `"Termin FIX geplant"`
+- **THEN** the delete is rejected before any CalDAV DELETE request
+- **AND** a German error message is returned

--- a/openspec/changes/prevent-fixed-appointment-modification/tasks.md
+++ b/openspec/changes/prevent-fixed-appointment-modification/tasks.md
@@ -1,0 +1,32 @@
+## 1. Extract reusable description parser
+
+- [ ] 1.1 Write failing `cargo test`s for a standalone `parse_daylite_reference(description: &str) -> Option<String>` function covering: valid `daylite:/<path>` first line, no reference present, empty description
+- [ ] 1.2 Extract the parsing logic out of `classify_event` (`src-tauri/src/integrations/calendar/events.rs`) into this function, satisfying the tests, and update `classify_event` to call it
+
+## 2. Extend Daylite project lookup with category
+
+- [ ] 2.1 Write failing `cargo test`s asserting `fetch_project_by_reference` returns `category` alongside name/status (protected category present, absent, `null`)
+- [ ] 2.2 Extend `fetch_project_by_reference` in `src-tauri/src/integrations/daylite/projects.rs` to include `category` in its return value, satisfying the tests
+- [ ] 2.3 Update the existing call site in `load_week_events` (`calendar/commands.rs`) to ignore the new field
+- [ ] 2.4 Add `FIXED_APPOINTMENT_CATEGORY: &str = "Termin FIX geplant"` constant alongside `OVERDUE_CATEGORY`
+
+## 3. Backend guard
+
+- [ ] 3.1 Write failing `cargo test`s for a `is_protected_event(href) -> bool`-style guard: protected category, non-protected category, no project reference, project lookup failure (fail open)
+- [ ] 3.2 Implement the guard in `src-tauri/src/integrations/calendar/commands.rs` (or a new module), fetching the event by `href`, parsing its Daylite reference, and checking the project's category, satisfying the tests
+- [ ] 3.3 Wire the guard into `update_assignment`: reject with a German error before the CalDAV PUT if the event is protected
+- [ ] 3.4 Wire the guard into `delete_assignment`: reject with a German error before the CalDAV DELETE if the event is protected
+- [ ] 3.5 Add `cargo test` coverage confirming `create_assignment` is unaffected by the guard
+
+## 4. Frontend disabled state
+
+- [ ] 4.1 Write failing `bun test`s for the assignment modal: save/delete disabled and German notice shown when the loaded assignment's project category is `"Termin FIX geplant"`
+- [ ] 4.2 Update `src/app/components/assignment-modal.tsx` to look up the project's category from the Daylite project cache and disable save/delete with a notice, satisfying the tests
+- [ ] 4.3 Add `bun test` coverage for surfacing the backend's German rejection message if a stale edit/delete is submitted anyway
+
+## 5. Verification
+
+- [ ] 5.1 Run `cargo test` and confirm all new and existing tests pass
+- [ ] 5.2 Run `bun test` and confirm all new and existing tests pass
+- [ ] 5.3 Run `bun lint` and fix any issues
+- [ ] 5.4 Manually verify in the running app: an assignment linked to a "Termin FIX geplant" project shows disabled edit/delete controls with a German notice, and a direct backend call to update/delete it is rejected


### PR DESCRIPTION
Add OpenSpec change with proposal, design, specs, and tasks for a
backend-side TTL cache of CalDAV week events, a shared HTTP client,
request coalescing, and targeted cache invalidation on writes,
replacing the frontend's full-cache wipe.