### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,15 +5,28 @@ Don't break sentences across multiple lines.
 
 ## Description
 
-## Notable decisions / What to look out for (optional)
+## Notable decisions
+
+<!-- optional -->
+
+## What to look out for
+
+<!-- optional -->
+
+## Screenshots / evidence of successful implementation
+
+<!--
+optional
+Make sure not to share any private data here.
+-->
 
 ## Reviewer checklist
 
 <!--
 Example:
-- [ ] `bun test` passes
-- [ ] `cargo test` passes
 - [ ] Manually verified the change in the app
+- [ ] Tested against a real Daylite/Planradar/CalDAV account
+- [ ] Checked behaviour with empty/missing data
 -->
 
 - [ ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!--
+One sentence per line in this PR description.
+Don't break sentences across multiple lines.
+-->
+
+## Description
+
+## Notable decisions / What to look out for (optional)
+
+## What should be checked by the reviewer?
+
+- [ ]
+- [ ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,30 +4,19 @@ Don't break sentences across multiple lines.
 -->
 
 ## Description
+<!-- Keep it short and simple -->
 
-## Notable decisions
+### Notable decisions
+<!-- optional, remove this section if not needed -->
 
-<!-- optional -->
+### What to look out for
+<!-- optional, remove this section if not needed -->
 
-## What to look out for
-
-<!-- optional -->
-
-## Screenshots / evidence of successful implementation
-
-<!--
-optional
-Make sure not to share any private data here.
--->
+### Screenshots / evidence of successful implementation
+<!-- optional, remove this section if not needed -->
 
 ## Reviewer checklist
-
-<!--
-Example:
-- [ ] Manually verified the change in the app
-- [ ] Tested against a real Daylite/Planradar/CalDAV account
-- [ ] Checked behaviour with empty/missing data
--->
+<!-- A checklist of manual steps the reviewer should do to verify the PR. -->
 
 - [ ]
 - [ ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,14 @@ Don't break sentences across multiple lines.
 
 ## Notable decisions / What to look out for (optional)
 
-## What should be checked by the reviewer?
+## Reviewer checklist
+
+<!--
+Example:
+- [ ] `bun test` passes
+- [ ] `cargo test` passes
+- [ ] Manually verified the change in the app
+-->
 
 - [ ]
 - [ ]


### PR DESCRIPTION
## Description

Adds a GitHub pull request template at `.github/pull_request_template.md`.
The template has sections for a description, notable decisions, what to look out for, optional screenshots/evidence, and a reviewer checklist.

## Notable decisions

Optional sections use a hidden HTML comment instead of an "(optional)" label in the heading, since GitHub strips comments from the rendered description.
Checklist examples focus on manual validation only, since `bun test`, `cargo test`, Biome, and Clippy already run in CI.

## What to look out for

There is no functional code change here, only a template file for future pull requests.

## Screenshots / evidence of successful implementation

Not applicable, this change only adds a markdown template file.

## Reviewer checklist

- [ ] Open a new PR against this branch and confirm the template renders correctly.
- [ ] Confirm the hidden comments do not leak into the rendered description.
