### PR TITLE
Add color-coded events spec: absences, assignments, conflicts

### DIFF
--- a/openspec/changes/color-coded-events/design.md
+++ b/openspec/changes/color-coded-events/design.md
@@ -7,6 +7,13 @@ The user also requires: any day where an absence and an appointment (assignment 
 Daylite project-status colors already occupy the DaisyUI `secondary`, `success`, `neutral`, `warning`, and `primary` tokens (`projectStatusToColor`, `src/app/types.ts:19-36`), and `error` is reserved exclusively for the new conflict indicator, so it cannot double as a category color.
 `accent` and `info` are the only other existing DaisyUI tokens, but the app's built-in dark theme ("business") reassigns hues inconsistently between light and dark for several tokens — most notably `accent` is teal (hue ≈185) in the light "corporate" theme but orange (hue ≈36) in the dark "business" theme, dangerously close to `error`'s dark hue (≈30). Reusing `accent` for a category color would therefore risk visually colliding with the conflict-red indicator in dark mode. This rules out reusing any existing semantic token for absence categories beyond the current `info` fallback.
 
+Assignment (Daylite) events are all blue for a different root cause, confirmed by code investigation.
+`toCellEvent()` colors assignments via `projectStatusToColor` (`src/app/types.ts:19-36`), the assignment picker only offers projects with status `new_status` or `in_progress` (`assignment-modal-filter` spec), and `map_project_status` (`src-tauri/src/integrations/daylite/projects.rs`) defaults every unknown or missing status to `new_status`.
+`new_status` maps to `bg-primary` (blue, hue ≈242 light / ≈251 dark) and `in_progress` maps to `bg-secondary` (desaturated blue, hue ≈257 light / ≈229 dark), so every assignment in the grid renders in one of two blue tones.
+Daylite itself colors projects by their category, and the API exposes those colors via `GET /categories` (fields `name`, nullable `hex_colour`, `is_active`, filterable with `entity=project`).
+The project `category` name is already part of `DayliteProjectSummaryDto` but is dropped on the way to the grid: `DayliteProjectCacheEntry` stores only reference, name, and status, `fetch_project_by_reference` returns only `(name, status)`, and `CalendarCellEvent` has no category field.
+The project cache (`daylite_cache.projects`) is additionally never written by any code path today, so every assignment resolves through the API fallback path.
+
 ## Goals / Non-Goals
 
 **Goals:**
@@ -14,11 +21,12 @@ Daylite project-status colors already occupy the DaisyUI `secondary`, `success`,
 - Reserve a red conflict indicator, paired with an icon and label (not color alone), for days where an absence and an appointment coincide.
 - Keep all category and conflict colors colorblind-safe and consistent across the light and dark themes.
 - Preserve current visual behavior (`bg-info/30`) for absence titles that don't match any known code.
+- Color assignment events with their Daylite category color so the grid matches what users see in Daylite, with the current status colors as fallback.
 
 **Non-Goals:**
 - No iCal `CATEGORIES` property parsing or CalDAV/Zep upstream changes.
-- No user-configurable category/color mapping — the code-to-color table is a fixed constant for this change.
-- No changes to assignment (project-status) or bare event coloring.
+- No user-configurable category/color mapping — the code-to-color table for absences is a fixed constant for this change, and Daylite category colors stay maintained in Daylite, not in this app.
+- No changes to bare event coloring.
 
 ## Decisions
 
@@ -59,17 +67,29 @@ Trim the title and check for equivalence to match the title.
 When a cell contains both an absence event and an assignment (`kind === "assignment"`) event for the same employee/day, add a red conflict indicator — a `ring-2 ring-error` (or equivalent border) on the cell plus a small warning icon (Lucide).
 Bare (non-assignment) events also trigger the conflict indicator.
 
+### Assignment events use the Daylite category color, status colors become the fallback
+The backend fetches `GET /categories?entity=project` and keeps a category-name-to-`hex_colour` map.
+Inactive categories (`is_active: false`) are still included, because existing projects can keep referencing a category after it was deactivated and should keep its color.
+The calendar pipeline threads the project's category through the resolution paths: `DayliteProjectCacheEntry` gains a category field, `fetch_project_by_reference` returns the category alongside name and status, and `CalendarCellEvent` gains a nullable `category_color` carrying the resolved hex value.
+Resolving the color in the backend keeps all third-party API knowledge in Rust, matching the project convention that the frontend only consumes typed Tauri responses.
+Because category colors are arbitrary hex values controlled in Daylite, they cannot be expressed as static Tailwind classes; the assignment card sets its background via an inline style and picks light or dark text by relative luminance of the hex color to stay readable.
+Fallback chain per assignment event: category `hex_colour` if the project has a category with a color, otherwise the existing `projectStatusToColor` mapping, otherwise the unchanged neutral placeholder color (`bg-base-300`, used when project resolution fails).
+
 ## Risks / Trade-offs
 
 - [`vacation` ↔ `special` CVD separation sits at the floor, not the full target] → Mitigated by the event title always being visible as text on the card (secondary encoding), per the skill's floor-band rule.
 - [Dark-surface contrast for the three new tokens sits below 3:1 at low opacity] → Accepted, same as the app's existing absence/status color usage (all applied as low-opacity washes with the title text as the readable channel, not the fill itself).
+- [Daylite category colors are user-controlled hex values and cannot be statically validated for CVD separation against the absence and conflict colors] → Accepted, the event title stays visible as text on every card, and the conflict indicator never relies on color alone (icon plus German label).
+- [Losing the status signal on assignment cards once category colors take over] → Accepted for now, the picker already restricts assignments to active statuses, so status carried almost no information in the grid.
 
 ## Migration Plan
 
 - Add the three new CSS custom properties to `src/app.css` first (additive, no visual change yet).
 - Implement and test the conflict detector in `src/app/types.ts`.
 - Wire the new colors and conflict indicator into `toCellEvent()`/`timetable-cell.tsx`.
-- Update the `employee-absence-display` spec delta and archive it alongside the code change.
+- Implement and test the Daylite categories fetch, then thread the category color through the calendar pipeline and regenerate the TypeScript bindings.
+- Wire the category color into assignment rendering with the status-color fallback.
+- Update the `employee-absence-display`, `assignment-persistence`, and `daylite-integration` spec deltas and archive them alongside the code change.
 
 ## Open Questions
 

--- a/openspec/changes/color-coded-events/proposal.md
+++ b/openspec/changes/color-coded-events/proposal.md
@@ -3,6 +3,11 @@
 Absence events are currently all rendered with the same color (`bg-info/30`) regardless of the absence type, so users cannot tell paid vacation, sick leave, or special leave apart at a glance in the planning grid.
 Distinguishing absence categories by color makes the weekly view scannable without opening each event, and flagging a day where an appointment collides with an absence surfaces a scheduling conflict that currently has no visual signal at all.
 
+Daylite assignment events have the same symptom for a different root cause: they all render in blue today, although Daylite itself shows each project in the color of its category.
+The grid derives assignment color from the Daylite project status (`projectStatusToColor` in `src/app/types.ts`), but the assignment picker only offers projects with status `new_status` or `in_progress`, so every plannable event maps to `bg-primary` or `bg-secondary`, which are both blue hues in the light and the dark theme.
+The backend additionally defaults every unknown or missing status to `new_status` (`map_project_status`), which also lands on blue.
+The project's category is already fetched from the Daylite API (`DayliteProjectSummaryDto.category`) but is dropped before it reaches the calendar pipeline, so the frontend never sees the one attribute that carries the color users know from Daylite.
+
 ## What Changes
 
 - Classify absence events into the six known Zep absence codes by keyword-matching the event's title (iCal `SUMMARY`): `UB` (paid vacation), `UU` (unpaid vacation), `KR` (sick), `Kro` (sick without pay), `SU` (special vacation), `FA` (time off in lieu).
@@ -13,17 +18,25 @@ Distinguishing absence categories by color makes the weekly view scannable witho
 - Add three new theme-level color tokens for these hues, validated for colorblind-safe separation from each other and from the existing Daylite project-status colors and the reserved conflict color (see design.md); unmatched/unrecognized absence titles keep the current `bg-info/30` color.
 - Highlight any day where an absence event and an appointment (assignment event) occur together for the same employee with a red conflict indicator, paired with an icon and a German label (not color alone), since a scheduling conflict is a status, not a category.
 - Align the `employee-absence-display` spec wording with actual rendering behavior (the spec currently says "warning color" while the code uses `bg-info/30`).
+- Fetch Daylite categories with their colors in the Rust backend via `GET /categories?entity=project` (`name`, nullable `hex_colour`, `is_active`).
+- Carry the resolved project's category color through the calendar event pipeline into `CalendarCellEvent` and color assignment events with it in the grid.
+- Keep the existing status-derived color as the fallback for assignment events whose project has no category or whose category has no color, and keep the neutral placeholder color for unresolved projects.
 
 ## Capabilities
 
 ### Modified Capabilities
 - `employee-absence-display`: "Absence event display" requirement changes from a single uniform absence color to a category-derived color per absence code, and gains a new conflict-highlighting requirement for days with both an absence and an appointment.
+- `assignment-persistence`: "Two-tier event display" and "Daylite project resolution" requirements change from status-derived assignment colors to the Daylite category color, with the status color as fallback.
+- `daylite-integration`: gains a new requirement for retrieving Daylite categories with their colors.
 
 ## Impact
 
 - `src/app.css`: add three new theme-level custom color properties for the vacation, sick, and time-off-in-lieu hues (validated with the dataviz skill's palette checks).
-- `src/app/types.ts`: extend `toCellEvent`/color derivation with a title-based absence category classifier covering all six codes, plus conflict detection when an absence and an assignment share a cell.
-- `src/app/components/timetable-cell.tsx`: render the conflict indicator (icon + German label) when a cell is flagged as conflicting.
+- `src/app/types.ts`: extend `toCellEvent`/color derivation with a title-based absence category classifier covering all six codes, conflict detection when an absence and an assignment share a cell, and the category-color-with-status-fallback logic for assignment events.
+- `src/app/components/timetable-cell.tsx`: render the conflict indicator (icon + German label) when a cell is flagged as conflicting, and render the assignment category color (dynamic hex value, so via inline style instead of a static Tailwind class).
 - `openspec/specs/employee-absence-display/spec.md`: delta to the "Absence event display" requirement.
-- No backend (Rust) changes required — absence titles already arrive via `EmployeeWeekEvents.events[].title`, and category-to-color mapping and conflict detection are pure frontend display concerns, matching the existing `projectStatusToColor` pattern.
-- Tests: `bun test` coverage for the classifier's code matches, the fallback, and conflict detection.
+- `openspec/specs/assignment-persistence/spec.md`: delta to the "Two-tier event display" and "Daylite project resolution" requirements.
+- `openspec/specs/daylite-integration/spec.md`: delta adding the category retrieval requirement.
+- The absence colors and conflict detection need no backend (Rust) changes, since absence titles already arrive via `EmployeeWeekEvents.events[].title`.
+- The assignment category colors do need backend changes: a categories fetch in `src-tauri/src/integrations/daylite`, threading the project category through `DayliteProjectCacheEntry`, `fetch_project_by_reference`, and `CalendarCellEvent` (`src-tauri/src/integrations/calendar`), plus regenerated TypeScript bindings.
+- Tests: `bun test` coverage for the classifier's code matches, the fallback, conflict detection, and the assignment color fallback chain, plus `cargo test` coverage for the categories fetch and the category threading through event resolution.

--- a/openspec/changes/color-coded-events/specs/assignment-persistence/spec.md
+++ b/openspec/changes/color-coded-events/specs/assignment-persistence/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Two-tier event display
+The system SHALL distinguish lkr-planner assignments from bare calendar events.
+
+#### Scenario: Display lkr-planner assignment
+- **WHEN** a VEVENT has a DESCRIPTION first line matching `daylite:/<path>`
+- **THEN** it is shown with the color of its Daylite project's category (`hex_colour`)
+- **AND** an edit affordance is shown
+
+#### Scenario: Assignment without a category color
+- **WHEN** a resolved Daylite project has no category or its category has no color
+- **THEN** the event is shown with the color derived from the Daylite project status instead
+
+#### Scenario: Readable text on category color
+- **WHEN** an assignment event is rendered with a category color
+- **THEN** the text color is chosen by the relative luminance of the category color so the title stays readable
+
+#### Scenario: Display bare event
+- **WHEN** a VEVENT has no structured Daylite project reference
+- **THEN** it is shown with neutral/grey styling
+- **AND** no edit affordance is shown (read-only)
+- **AND** covers legacy manually-created events and employee blockers
+
+#### Scenario: Display event start and end time
+- **WHEN** a VEVENT has a start time (non-all-day event)
+- **THEN** the start time is shown in HH:MM format on the left of the event card
+- **AND** the end time is shown below the start time if present
+- **AND** all-day events show no time
+
+#### Scenario: Event card hover feedback
+- **WHEN** the user hovers over any event card
+- **THEN** a visual hover indicator is shown
+
+#### Scenario: Long event titles
+- **WHEN** an event title exceeds the card width
+- **THEN** the title wraps to multiple lines
+- **AND** the card grows vertically to accommodate the text
+
+### Requirement: Daylite project resolution
+The system SHALL resolve project details for lkr-planner events.
+
+#### Scenario: Project found in cache
+- **WHEN** a VEVENT references a Daylite project
+- **AND** the project is present in the local Daylite cache
+- **THEN** the project name and category color are displayed from cache
+- **AND** the status color is used when no category color is cached
+
+#### Scenario: Project not in cache — API fallback
+- **WHEN** a VEVENT references a Daylite project
+- **AND** the project is not in the local cache
+- **THEN** the system queries the Daylite API for the project details including its category
+- **AND** displays the resolved name and category color on success
+- **AND** the status color is used when the project has no category color
+
+#### Scenario: Project resolution fails
+- **WHEN** a VEVENT references a Daylite project
+- **AND** neither cache lookup nor API query succeeds
+- **THEN** a German placeholder is shown: `"Beschreibung für [event SUMMARY] konnte nicht abgerufen werden"`
+- **AND** neutral color is used

--- a/openspec/changes/color-coded-events/specs/daylite-integration/spec.md
+++ b/openspec/changes/color-coded-events/specs/daylite-integration/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Category color retrieval
+The system SHALL retrieve Daylite categories with their colors for coloring project events.
+
+#### Scenario: Fetch project categories
+- **WHEN** the system needs category colors for the planning grid
+- **THEN** it requests `GET /categories` with the `entity=project` filter
+- **AND** parses `name` and `hex_colour` for each category into a name-to-color map
+
+#### Scenario: Category without a color
+- **WHEN** a category's `hex_colour` is null
+- **THEN** the category yields no color
+- **AND** events of projects in that category fall back to the status-derived color
+
+#### Scenario: Inactive categories keep their color
+- **WHEN** a category has `is_active` set to false
+- **AND** an existing project still references that category
+- **THEN** the category's color is still used for that project's events

--- a/openspec/changes/color-coded-events/tasks.md
+++ b/openspec/changes/color-coded-events/tasks.md
@@ -12,3 +12,12 @@
 - [ ] 3.1 Update `toCellEvent()` in `src/app/types.ts` to call `absenceCategoryColor(event.title)` for `kind === "absence"` instead of the hardcoded `bg-info/30`
 - [ ] 3.2 Update `src/app/components/timetable-cell.tsx` to render a red conflict indicator (ring/border + Lucide warning icon) when the conflict detector flags a cell
 - [ ] 3.3 Add/update `bun test` coverage for `toCellEvent()` producing the correct color per absence code, and for the conflict indicator rendering only when flagged
+
+## 4. Daylite category colors for assignment events
+
+- [ ] 4.1 Write failing `cargo test`s for a categories fetch core: sends `GET /categories` with `entity=project`, parses `name` and nullable `hex_colour`, and keeps inactive categories
+- [ ] 4.2 Implement the categories fetch in `src-tauri/src/integrations/daylite`, satisfying the tests
+- [ ] 4.3 Write failing `cargo test`s for the calendar pipeline: `resolve_event` sets `category_color` on `CalendarCellEvent` from both the cache and the API fallback path, and leaves it unset for bare events, absence events, and unresolved projects
+- [ ] 4.4 Thread the project category through `DayliteProjectCacheEntry`, `fetch_project_by_reference`, and `CalendarCellEvent`, regenerate the TypeScript bindings, satisfying the tests
+- [ ] 4.5 Write failing `bun test`s for assignment coloring: event with `category_color` uses the hex value, event without one falls back to the status color, unresolved event keeps `bg-base-300`
+- [ ] 4.6 Render the category color on assignment cards in `timetable-cell.tsx` (inline style with luminance-based text color), satisfying the tests


### PR DESCRIPTION
## Description

Add comprehensive OpenSpec documentation for the color-coded events feature, covering absence category colors, assignment category colors from Daylite, and conflict indicators.
This change documents the requirements, design decisions, and implementation tasks for distinguishing absence types and assignment projects by color in the planning grid, plus flagging scheduling conflicts.

### Notable decisions

The spec establishes a three-part color strategy:
- Absence events use six category-specific colors derived from Zep absence codes (UB, UU, KR, Kro, SU, FA), with a fallback to the current `bg-info/30` for unrecognized titles.
- Assignment events use their Daylite project's category color (fetched via `GET /categories?entity=project`), with the existing status-derived color as fallback and neutral grey for unresolved projects.
- Conflict indicators (red ring + warning icon + German label) flag days where an absence and an appointment coincide, ensuring the signal does not rely on color alone.

The backend threads the project category through the calendar pipeline (`DayliteProjectCacheEntry` → `fetch_project_by_reference` → `CalendarCellEvent`), keeping all third-party API knowledge in Rust.
The frontend renders category colors via inline styles (since they are arbitrary hex values) and picks text color by relative luminance for readability.

### What to look out for

- The spec adds two new capability deltas (`assignment-persistence` and `daylite-integration`) alongside the existing `employee-absence-display` delta.
- Task section 4 (Daylite category colors) requires both Rust backend changes (categories fetch, pipeline threading) and TypeScript binding regeneration.
- The fallback chain for assignment colors is: category `hex_colour` → status color → neutral placeholder; this preserves current behavior when category data is missing.
- Inactive Daylite categories are still included in the color map, since existing projects can reference deactivated categories and should keep their color.

https://claude.ai/code/session_01Kx2kVUfWBYA5LPeSy9rfo4