### PR TITLE
Navigate weeks with a trackpad swipe on the planning grid

### DIFF
--- a/openspec/specs/week-swipe-navigation/spec.md
+++ b/openspec/specs/week-swipe-navigation/spec.md
@@ -1,0 +1,89 @@
+## Purpose
+
+Let planners move between calendar weeks with a two-finger trackpad swipe on the planning grid, so browsing the plan feels continuous instead of requiring a trip to the navigation buttons in the header.
+
+## Requirements
+
+### Requirement: Horizontal swipe pulls in the neighbouring week
+The system SHALL treat a horizontal two-finger swipe on the planning grid as a week gesture that pulls the neighbouring week in from the side the swipe comes from.
+Swiping towards the left SHALL pull the next week in from the right edge, swiping towards the right SHALL pull the previous week in from the left edge.
+The incoming week SHALL cover the current week rather than push it aside, and SHALL follow the fingers one to one until it has covered the grid completely.
+
+#### Scenario: Pulling the next week in
+- **GIVEN** the planning grid shows a week
+- **WHEN** the user swipes horizontally towards the left
+- **THEN** the next week is drawn over the grid from the right edge
+- **AND** it moves with the swipe, exposing more of itself the further the swipe goes
+
+#### Scenario: Pulling the previous week in
+- **GIVEN** the planning grid shows a week
+- **WHEN** the user swipes horizontally towards the right
+- **THEN** the previous week is drawn over the grid from the left edge
+
+#### Scenario: Vertical scrolling is untouched
+- **GIVEN** the planning grid is taller than the window
+- **WHEN** the user scrolls vertically, or diagonally with a mostly vertical motion
+- **THEN** the grid scrolls as before
+- **AND** no week is pulled in
+
+### Requirement: The incoming week shows the events already loaded for it
+The system SHALL render the incoming week from the assignments already cached for it, including the neighbouring weeks the planning view prefetches.
+A week with no cached assignments SHALL be shown as an empty grid with that week's day headers, and SHALL fill in once its assignments arrive.
+
+#### Scenario: Prefetched week
+- **GIVEN** the assignments of the next week are already in the cache
+- **WHEN** the user pulls that week in
+- **THEN** its day headers and its assignment cards are visible while the gesture runs
+
+#### Scenario: Week not loaded yet
+- **GIVEN** the assignments of the next week are not cached
+- **WHEN** the user pulls that week in
+- **THEN** the week is shown with its day headers and without assignment cards
+- **AND** the assignments appear once the load for that week finishes
+
+### Requirement: A swipe past the commit threshold changes the week
+The system SHALL complete the gesture once the swipe ends, using how far the week was pulled in as the decision.
+A week pulled in by at least 20 percent of the grid width SHALL slide the rest of the way, cover the current week and become the displayed week.
+A week pulled in by less than that SHALL slide back off the edge it came from, leaving the displayed week unchanged.
+
+#### Scenario: Committed swipe
+- **GIVEN** the user has pulled the next week in by at least 20 percent of the grid width
+- **WHEN** the swipe ends
+- **THEN** the next week slides all the way over the current one
+- **AND** the planning view shows the next week afterwards
+
+#### Scenario: Cancelled swipe
+- **GIVEN** the user has pulled the next week in by less than 20 percent of the grid width
+- **WHEN** the swipe ends
+- **THEN** the pulled-in week slides back out of view
+- **AND** the planning view still shows the same week
+
+#### Scenario: One swipe changes one week
+- **GIVEN** a swipe has just changed the week
+- **WHEN** the trackpad's momentum keeps the wheel firing afterwards
+- **THEN** no further week change is started until the input goes quiet
+
+### Requirement: A grid wider than the window scrolls before it swipes
+The system SHALL let a planning grid that does not fit the window scroll horizontally first, and SHALL start the week gesture only from a horizontal swipe that continues past the scroll edge it is heading for.
+The incoming week SHALL be shown at the same horizontal offset as the grid it covers.
+
+#### Scenario: Scrolling to the edge first
+- **GIVEN** the planning grid is wider than the window and is not scrolled to its right edge
+- **WHEN** the user swipes horizontally towards the left
+- **THEN** the grid scrolls right as before
+- **AND** no week is pulled in until the grid has reached its right edge
+
+#### Scenario: Swiping from the edge
+- **GIVEN** the planning grid is scrolled to its right edge
+- **WHEN** the user keeps swiping towards the left
+- **THEN** the next week is pulled in
+- **AND** it shows the same columns as the grid it covers
+
+### Requirement: An appointment drag keeps week navigation to itself
+The system SHALL suppress the swipe gesture while an assignment card is being dragged, so the week only changes through the drag's own edge hovering.
+
+#### Scenario: Swipe during a drag
+- **GIVEN** the user is dragging an assignment card
+- **WHEN** a horizontal swipe reaches the grid
+- **THEN** no week is pulled in
+- **AND** the drag keeps navigating weeks by hovering the window edge

--- a/src/app/components/week-table.tsx
+++ b/src/app/components/week-table.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef } from "react";
+import type {
+  CalendarCellEvent,
+  EmployeeSetting,
+  Holiday,
+  PlanningContactRecord,
+} from "../../generated/tauri";
+import type { DropPreview } from "../hooks/use-appointment-drag";
+import { toLocalISODate } from "../util";
+import { TimetableHeader } from "./timetable-header";
+import { TimetableRow } from "./timetable-row";
+
+export function WeekTable({
+  weekDays,
+  employees,
+  employeeSettings,
+  eventsByEmployee,
+  errorsByEmployee,
+  holidays,
+  isEmployeeLoading,
+  dropPreview = null,
+  draggedUid = null,
+  onOpenIcalDialog,
+  onReloadAssignments,
+}: WeekTableProps) {
+  const holidayByDate = new Map(holidays.map((h) => [h.date, h.name]));
+  const holidayDates = new Set(holidays.map((h) => h.date));
+
+  // WKWebView can leave a card's previous pixels when a reload rewrites the cells, so a re-slotted card renders torn until a repaint clears it.
+  // Promoting the grid to its own compositing layer and releasing it on the next frame re-rasterizes every cell without affecting layout.
+  const gridRef = useRef<HTMLTableElement>(null);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: eventsByEmployee is the repaint trigger, not a value the effect body reads.
+  useEffect(() => {
+    const grid = gridRef.current;
+    if (!grid) return;
+    grid.style.transform = "translateZ(0)";
+    const frame = requestAnimationFrame(() => {
+      grid.style.transform = "";
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [eventsByEmployee]);
+
+  return (
+    <table ref={gridRef} className="table table-fixed border-collapse">
+      <thead className="text-base-content">
+        <tr>
+          <th className="w-40 p-4 font-bold">Mitarbeiter</th>
+          {weekDays.map((day) => (
+            <TimetableHeader
+              key={day.getTime()}
+              day={day}
+              holiday={holidayByDate.get(toLocalISODate(day))}
+            />
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {employees.map((employee, index) => (
+          <TimetableRow
+            key={employee.self || `employee-${index}`}
+            employee={employee}
+            calendarEvents={eventsByEmployee[employee.self] ?? []}
+            calendarError={errorsByEmployee[employee.self] ?? null}
+            week={{ days: weekDays, holidayDates }}
+            employeeSetting={
+              employeeSettings.find(
+                (s) => s.dayliteContactReference === employee.self,
+              ) ?? null
+            }
+            dropPreview={dropPreview}
+            draggedUid={draggedUid}
+            onOpenIcalDialog={onOpenIcalDialog}
+            onReloadAssignments={onReloadAssignments}
+          />
+        ))}
+        {!isEmployeeLoading && employees.length === 0 ? (
+          <tr key="no-employees-row">
+            <td
+              className="p-4 text-base-content/70"
+              colSpan={weekDays.length + 1}
+            >
+              Keine Mitarbeiter gefunden
+            </td>
+          </tr>
+        ) : null}
+      </tbody>
+    </table>
+  );
+}
+
+export interface WeekTableProps {
+  weekDays: Date[];
+  employees: PlanningContactRecord[];
+  employeeSettings: EmployeeSetting[];
+  eventsByEmployee: Record<string, CalendarCellEvent[]>;
+  errorsByEmployee: Record<string, string>;
+  holidays: Holiday[];
+  isEmployeeLoading: boolean;
+  dropPreview?: DropPreview | null;
+  draggedUid?: string | null;
+  onOpenIcalDialog: (employee: PlanningContactRecord) => void;
+  onReloadAssignments: () => void;
+}

--- a/src/app/hooks/use-planning-assignments.ts
+++ b/src/app/hooks/use-planning-assignments.ts
@@ -10,7 +10,7 @@ import { useLeadingDebounce } from "./use-leading-debounce";
 type EmployeeEvents = Record<string, CalendarCellEvent[]>;
 type EmployeeErrors = Record<string, string>;
 
-interface WeekData {
+export interface WeekData {
   eventsByEmployee: EmployeeEvents;
   errorsByEmployee: EmployeeErrors;
 }
@@ -23,6 +23,7 @@ export interface PlanningAssignmentsState {
   loadedWeekStart: string | null;
   reloadAssignments: () => void;
   invalidateWeeksContaining: (uid: string) => void;
+  getCachedWeek: (weekStart: string) => WeekData | null;
 }
 
 export function usePlanningAssignments(
@@ -127,6 +128,11 @@ export function usePlanningAssignments(
     }
   }, []);
 
+  const getCachedWeek = useCallback(
+    (ws: string) => cache.current[ws] ?? null,
+    [],
+  );
+
   return useMemo(
     () => ({
       eventsByEmployee,
@@ -136,6 +142,7 @@ export function usePlanningAssignments(
       loadedWeekStart,
       reloadAssignments,
       invalidateWeeksContaining,
+      getCachedWeek,
     }),
     [
       eventsByEmployee,
@@ -145,6 +152,7 @@ export function usePlanningAssignments(
       loadedWeekStart,
       reloadAssignments,
       invalidateWeeksContaining,
+      getCachedWeek,
     ],
   );
 }

--- a/src/app/hooks/use-week-swipe.ts
+++ b/src/app/hooks/use-week-swipe.ts
@@ -1,0 +1,88 @@
+import type { RefObject } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { SwipeDirection, SwipePreview, SwipeState } from "../week-swipe";
+import {
+  advanceSwipe,
+  endSwipe,
+  settleSwipe,
+  swipePreview,
+  swipeQuietMs,
+  swipeSettleMs,
+} from "../week-swipe";
+
+interface UseWeekSwipeArgs {
+  containerRef: RefObject<HTMLElement | null>;
+  onNavigate: (direction: SwipeDirection) => void;
+  isDisabled: boolean;
+}
+
+export function useWeekSwipe({
+  containerRef,
+  onNavigate,
+  isDisabled,
+}: UseWeekSwipeArgs): SwipePreview | null {
+  const [state, setState] = useState<SwipeState>({ phase: "idle" });
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const onNavigateRef = useRef(onNavigate);
+  onNavigateRef.current = onNavigate;
+
+  const quietTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scheduleQuiet = useCallback(() => {
+    if (quietTimer.current !== null) clearTimeout(quietTimer.current);
+    quietTimer.current = setTimeout(() => {
+      quietTimer.current = null;
+      setState((current) => endSwipe(current));
+    }, swipeQuietMs);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (quietTimer.current !== null) clearTimeout(quietTimer.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || isDisabled) return;
+
+    const onWheel = (event: WheelEvent) => {
+      const next = advanceSwipe(stateRef.current, {
+        deltaX: event.deltaX,
+        deltaY: event.deltaY,
+        scrollLeft: container.scrollLeft,
+        scrollWidth: container.scrollWidth,
+        clientWidth: container.clientWidth,
+      });
+      // Only a gesture that is running (or just ran) owns the wheel; anything else stays the grid's own scroll.
+      if (next.phase === "idle") return;
+      event.preventDefault();
+      stateRef.current = next;
+      setState(next);
+      scheduleQuiet();
+    };
+
+    container.addEventListener("wheel", onWheel, { passive: false });
+    return () => container.removeEventListener("wheel", onWheel);
+  }, [containerRef, isDisabled, scheduleQuiet]);
+
+  // An appointment drag takes over week navigation through its own edge hovering.
+  useEffect(() => {
+    if (isDisabled) setState({ phase: "idle" });
+  }, [isDisabled]);
+
+  useEffect(() => {
+    if (state.phase !== "settling") return;
+    const timer = setTimeout(() => {
+      if (state.isCommitted) onNavigateRef.current(state.direction);
+      setState(settleSwipe(state));
+    }, swipeSettleMs);
+    return () => clearTimeout(timer);
+  }, [state]);
+
+  useEffect(() => {
+    if (state.phase === "cooldown") scheduleQuiet();
+  }, [state, scheduleQuiet]);
+
+  return swipePreview(state);
+}

--- a/src/app/page.spec.tsx
+++ b/src/app/page.spec.tsx
@@ -28,6 +28,7 @@ const defaultAssignmentState: PlanningGridAssignmentState = {
   loadedWeekStart: null,
   reloadAssignments: () => {},
   invalidateWeeksContaining: () => {},
+  getCachedWeek: () => null,
 };
 
 const defaultHolidaysState: HolidaysState = {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,15 +22,16 @@ import {
   assignmentStripClass,
   categoryStrip,
 } from "./components/timetable-cell";
-import { TimetableHeader } from "./components/timetable-header";
-import { TimetableRow } from "./components/timetable-row";
+import { WeekTable } from "./components/week-table";
 import { filterVisibleEmployees } from "./employee-visibility";
 import type { AppointmentDragPayload } from "./hooks/use-appointment-drag";
 import { useAppointmentDrag } from "./hooks/use-appointment-drag";
 import { type HolidaysState, useHolidays } from "./hooks/use-holidays";
 import type { PlanningAssignmentsState } from "./hooks/use-planning-assignments";
 import { usePlanningEmployees } from "./hooks/use-planning-employees";
-import { getWeekDays, toLocalISODate } from "./util";
+import { useWeekSwipe } from "./hooks/use-week-swipe";
+import { getWeekDays, shiftWeekDays, toLocalISODate } from "./util";
+import { swipeSettleMs } from "./week-swipe";
 
 // The pointer, not the dragged card's box, picks the target cell and the position within the cell
 const collisionDetection: CollisionDetection = (args) => {
@@ -131,8 +132,6 @@ export function PlanningGridTable({
     errorMessage: holidayErrorMessage,
     reloadHolidays,
   } = holidaysState;
-  const holidayByDate = new Map(holidays.map((h) => [h.date, h.name]));
-  const holidayDates = new Set(holidays.map((h) => h.date));
   const visibleEmployees = filterVisibleEmployees(
     employees,
     employeeSettings,
@@ -161,118 +160,124 @@ export function PlanningGridTable({
     assignmentState.loadedWeekStart,
   );
 
-  // WKWebView can leave a card's previous pixels when a reload rewrites the cells, so a re-slotted card renders torn until a repaint clears it.
-  // Promoting the grid to its own compositing layer and releasing it on the next frame re-rasterizes every cell without affecting layout.
-  const gridRef = useRef<HTMLTableElement>(null);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: eventsByEmployee is the repaint trigger, not a value the effect body reads.
+  const scrollRef = useRef<HTMLElement>(null);
+  const swipe = useWeekSwipe({
+    containerRef: scrollRef,
+    onNavigate: onNavigateWeek ?? (() => {}),
+    isDisabled: !onNavigateWeek || isDragActive,
+  });
+  const incomingDays = swipe ? shiftWeekDays(weekDays, swipe.direction) : null;
+  const incomingWeek = incomingDays
+    ? assignmentState.getCachedWeek(toLocalISODate(incomingDays[0]))
+    : null;
+
+  // A gesture can only start at a scroll edge, so a grid too wide for the window is parked
+  // to one side; the incoming week has to arrive at the same offset or the columns jump on handover.
+  const incomingRef = useRef<HTMLElement>(null);
+  const hasIncoming = incomingDays !== null;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: hasIncoming marks the mount of the incoming week, not a value the effect body reads.
   useEffect(() => {
-    const grid = gridRef.current;
-    if (!grid) return;
-    grid.style.transform = "translateZ(0)";
-    const frame = requestAnimationFrame(() => {
-      grid.style.transform = "";
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [eventsByEmployee]);
+    if (incomingRef.current && scrollRef.current) {
+      incomingRef.current.scrollLeft = scrollRef.current.scrollLeft;
+    }
+  }, [hasIncoming]);
 
   return (
-    <section className="w-full h-full overflow-auto">
-      <ReloadableAlert
-        message={employeeErrorMessage}
-        onReload={reloadEmployees}
-      />
-      <ReloadableAlert
-        message={assignmentErrorMessage}
-        onReload={reloadAssignments}
-      />
-      <ReloadableAlert
-        message={holidayErrorMessage}
-        onReload={reloadHolidays}
-        variant="warning"
-      />
-      {drag.errorMessage ? (
-        <section className="toast toast-top toast-center z-50">
-          <section className="alert alert-error">
-            <span>{drag.errorMessage}</span>
-            <button
-              type="button"
-              className="btn btn-sm"
-              onClick={drag.clearError}
-            >
-              Schließen
-            </button>
+    <section className="w-full h-full relative overflow-hidden">
+      <section ref={scrollRef} className="w-full h-full overflow-auto">
+        <ReloadableAlert
+          message={employeeErrorMessage}
+          onReload={reloadEmployees}
+        />
+        <ReloadableAlert
+          message={assignmentErrorMessage}
+          onReload={reloadAssignments}
+        />
+        <ReloadableAlert
+          message={holidayErrorMessage}
+          onReload={reloadHolidays}
+          variant="warning"
+        />
+        {drag.errorMessage ? (
+          <section className="toast toast-top toast-center z-50">
+            <section className="alert alert-error">
+              <span>{drag.errorMessage}</span>
+              <button
+                type="button"
+                className="btn btn-sm"
+                onClick={drag.clearError}
+              >
+                Schließen
+              </button>
+            </section>
           </section>
-        </section>
+        ) : null}
+        <DndContext
+          sensors={dragSensors}
+          collisionDetection={collisionDetection}
+          onDragStart={drag.onDragStart}
+          onDragMove={drag.onDragMove}
+          onDragEnd={drag.onDragEnd}
+          onDragCancel={drag.onDragCancel}
+        >
+          <DropzoneMeasurementTicker />
+          <WeekTable
+            weekDays={weekDays}
+            employees={visibleEmployees}
+            employeeSettings={employeeSettings}
+            eventsByEmployee={eventsByEmployee}
+            errorsByEmployee={errorsByEmployee}
+            holidays={holidays}
+            isEmployeeLoading={isEmployeeLoading}
+            dropPreview={drag.dropPreview}
+            draggedUid={drag.activePayload?.uid ?? null}
+            onOpenIcalDialog={onOpenIcalDialog}
+            onReloadAssignments={reloadAssignments}
+          />
+          {/* The document guard is not about Tauri: bun tests render this grid
+              through react-dom/server, where portals and `document` do not exist. */}
+          {typeof document === "undefined"
+            ? null
+            : createPortal(
+                <DragOverlay style={{ pointerEvents: "none" }}>
+                  {drag.activePayload ? (
+                    <DragPreviewCard payload={drag.activePayload} />
+                  ) : null}
+                </DragOverlay>,
+                document.body,
+              )}
+        </DndContext>
+      </section>
+
+      {swipe && incomingDays ? (
+        <aside
+          ref={incomingRef}
+          inert
+          // Without pointer-events-none the covering week swallows the wheel events that drive the gesture.
+          className="absolute inset-0 overflow-hidden bg-base-100 shadow-2xl pointer-events-none"
+          style={{
+            transform: `translateX(${swipe.translatePercent}%)`,
+            transition: swipe.isAnimating
+              ? `transform ${swipeSettleMs}ms ease-out`
+              : "none",
+          }}
+        >
+          {/* Its own context keeps the incoming week's cells out of the running drag's drop targets. */}
+          <DndContext>
+            <WeekTable
+              weekDays={incomingDays}
+              employees={visibleEmployees}
+              employeeSettings={employeeSettings}
+              eventsByEmployee={incomingWeek?.eventsByEmployee ?? {}}
+              errorsByEmployee={incomingWeek?.errorsByEmployee ?? {}}
+              holidays={holidays}
+              isEmployeeLoading={isEmployeeLoading}
+              onOpenIcalDialog={onOpenIcalDialog}
+              onReloadAssignments={reloadAssignments}
+            />
+          </DndContext>
+        </aside>
       ) : null}
-      <DndContext
-        sensors={dragSensors}
-        collisionDetection={collisionDetection}
-        onDragStart={drag.onDragStart}
-        onDragMove={drag.onDragMove}
-        onDragEnd={drag.onDragEnd}
-        onDragCancel={drag.onDragCancel}
-      >
-        <DropzoneMeasurementTicker />
-        <table ref={gridRef} className="table table-fixed border-collapse">
-          <thead className="text-base-content">
-            <tr>
-              <th className="w-40 p-4 font-bold">Mitarbeiter</th>
-              {weekDays.map((day) => {
-                const isoDay = toLocalISODate(day);
-                return (
-                  <TimetableHeader
-                    key={day.getTime()}
-                    day={day}
-                    holiday={holidayByDate.get(isoDay)}
-                  />
-                );
-              })}
-            </tr>
-          </thead>
-          <tbody>
-            {visibleEmployees.map((employee, index) => (
-              <TimetableRow
-                key={employee.self || `employee-${index}`}
-                employee={employee}
-                calendarEvents={eventsByEmployee[employee.self] ?? []}
-                calendarError={errorsByEmployee[employee.self] ?? null}
-                week={{ days: weekDays, holidayDates }}
-                employeeSetting={
-                  employeeSettings.find(
-                    (s) => s.dayliteContactReference === employee.self,
-                  ) ?? null
-                }
-                dropPreview={drag.dropPreview}
-                draggedUid={drag.activePayload?.uid ?? null}
-                onOpenIcalDialog={onOpenIcalDialog}
-                onReloadAssignments={reloadAssignments}
-              />
-            ))}
-            {!isEmployeeLoading && visibleEmployees.length === 0 ? (
-              <tr key="no-employees-row">
-                <td
-                  className="p-4 text-base-content/70"
-                  colSpan={weekDays.length + 1}
-                >
-                  Keine Mitarbeiter gefunden
-                </td>
-              </tr>
-            ) : null}
-          </tbody>
-        </table>
-        {/* The document guard is not about Tauri: bun tests render this grid
-            through react-dom/server, where portals and `document` do not exist. */}
-        {typeof document === "undefined"
-          ? null
-          : createPortal(
-              <DragOverlay style={{ pointerEvents: "none" }}>
-                {drag.activePayload ? (
-                  <DragPreviewCard payload={drag.activePayload} />
-                ) : null}
-              </DragOverlay>,
-              document.body,
-            )}
-      </DndContext>
 
       <MoveReconciliationDialog
         reconciliation={drag.reconciliation}

--- a/src/app/util.spec.ts
+++ b/src/app/util.spec.ts
@@ -6,7 +6,13 @@ import {
   it,
   setSystemTime,
 } from "bun:test";
-import { getWeekDays, getWeekStart, isToday, toLocalISODate } from "./util";
+import {
+  getWeekDays,
+  getWeekStart,
+  isToday,
+  shiftWeekDays,
+  toLocalISODate,
+} from "./util";
 
 describe("util", () => {
   beforeAll(() => {
@@ -132,6 +138,29 @@ describe("util", () => {
           }
         }
       }
+    });
+  });
+
+  describe("shiftWeekDays", () => {
+    it("moves every day one week forward", () => {
+      const shifted = shiftWeekDays(getWeekDays(0), 1);
+      expect(shifted.map(toLocalISODate)).toEqual(
+        getWeekDays(1).map(toLocalISODate),
+      );
+    });
+
+    it("moves every day one week back", () => {
+      const shifted = shiftWeekDays(getWeekDays(0), -1);
+      expect(shifted.map(toLocalISODate)).toEqual(
+        getWeekDays(-1).map(toLocalISODate),
+      );
+    });
+
+    it("keeps the days at local midnight across a DST switch", () => {
+      const beforeDst = [new Date(2026, 2, 23), new Date(2026, 2, 27)];
+      const shifted = shiftWeekDays(beforeDst, 1);
+      expect(shifted.map(toLocalISODate)).toEqual(["2026-03-30", "2026-04-03"]);
+      expect(shifted.every((day) => day.getHours() === 0)).toBe(true);
     });
   });
 

--- a/src/app/util.ts
+++ b/src/app/util.ts
@@ -17,6 +17,17 @@ export function getWeekDays(weekOffset: number, showWeekend = false) {
   );
 }
 
+export function shiftWeekDays(days: Date[], weekOffset: number): Date[] {
+  return days.map(
+    (day) =>
+      new Date(
+        day.getFullYear(),
+        day.getMonth(),
+        day.getDate() + weekOffset * 7,
+      ),
+  );
+}
+
 export function isToday(day: Date) {
   const today = new Date();
   return day.toDateString() === today.toDateString();

--- a/src/app/week-swipe.spec.ts
+++ b/src/app/week-swipe.spec.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "bun:test";
+import type { SwipeState, WheelSample } from "./week-swipe";
+import {
+  advanceSwipe,
+  endSwipe,
+  settleSwipe,
+  swipeCommitRatio,
+  swipePreview,
+} from "./week-swipe";
+
+const width = 1000;
+
+/** A grid whose table fits, so both scroll edges are reached at once. */
+function wheel(deltaX: number, overrides: Partial<WheelSample> = {}) {
+  return {
+    deltaX,
+    deltaY: 0,
+    scrollLeft: 0,
+    scrollWidth: width,
+    clientWidth: width,
+    ...overrides,
+  };
+}
+
+const idle: SwipeState = { phase: "idle" };
+
+function dragging(direction: -1 | 1, offset: number): SwipeState {
+  return { phase: "dragging", direction, offset, width };
+}
+
+describe("advanceSwipe", () => {
+  it("should ignore a vertically dominant wheel event", () => {
+    expect(advanceSwipe(idle, wheel(10, { deltaY: 40 }))).toBe(idle);
+  });
+
+  it("should ignore wheel noise below the activation delta", () => {
+    expect(advanceSwipe(idle, wheel(1))).toBe(idle);
+  });
+
+  it("should start the next-week gesture at the right scroll edge", () => {
+    expect(advanceSwipe(idle, wheel(30))).toEqual(dragging(1, 30));
+  });
+
+  it("should start the previous-week gesture at the left scroll edge", () => {
+    expect(advanceSwipe(idle, wheel(-30))).toEqual(dragging(-1, 30));
+  });
+
+  it("should let the grid scroll while it is not yet at the right edge", () => {
+    const sample = wheel(30, { scrollWidth: 1600, scrollLeft: 200 });
+    expect(advanceSwipe(idle, sample)).toBe(idle);
+  });
+
+  it("should let the grid scroll while it is not yet at the left edge", () => {
+    const sample = wheel(-30, { scrollWidth: 1600, scrollLeft: 200 });
+    expect(advanceSwipe(idle, sample)).toBe(idle);
+  });
+
+  it("should start once the grid has reached the right edge", () => {
+    const sample = wheel(30, { scrollWidth: 1600, scrollLeft: 600 });
+    expect(advanceSwipe(idle, sample)).toEqual(dragging(1, 30));
+  });
+
+  it("should accumulate further pull in the same direction", () => {
+    expect(advanceSwipe(dragging(1, 30), wheel(20))).toEqual(dragging(1, 50));
+    expect(advanceSwipe(dragging(-1, 30), wheel(-20))).toEqual(
+      dragging(-1, 50),
+    );
+  });
+
+  it("should push the week back out when the swipe reverses", () => {
+    expect(advanceSwipe(dragging(1, 50), wheel(-20))).toEqual(dragging(1, 30));
+  });
+
+  it("should keep the pulled distance within the grid width", () => {
+    expect(advanceSwipe(dragging(1, 900), wheel(400))).toEqual(
+      dragging(1, width),
+    );
+    expect(advanceSwipe(dragging(1, 30), wheel(-400))).toEqual(dragging(1, 0));
+  });
+
+  it("should keep a started gesture on its own axis", () => {
+    const sample = wheel(20, { deltaY: 60 });
+    expect(advanceSwipe(dragging(1, 30), sample)).toEqual(dragging(1, 30));
+  });
+
+  it("should swallow the momentum tail while the week settles", () => {
+    const settling: SwipeState = {
+      phase: "settling",
+      direction: 1,
+      isCommitted: true,
+    };
+    expect(advanceSwipe(settling, wheel(30))).toBe(settling);
+  });
+
+  it("should not start a second gesture during the cooldown", () => {
+    const cooldown: SwipeState = { phase: "cooldown" };
+    expect(advanceSwipe(cooldown, wheel(30))).toBe(cooldown);
+  });
+});
+
+describe("endSwipe", () => {
+  it("should snap back when the week was not pulled in far enough", () => {
+    const state = dragging(1, width * swipeCommitRatio - 1);
+    expect(endSwipe(state)).toEqual({
+      phase: "settling",
+      direction: 1,
+      isCommitted: false,
+    });
+  });
+
+  it("should slide the week over once the commit ratio is reached", () => {
+    const state = dragging(-1, width * swipeCommitRatio);
+    expect(endSwipe(state)).toEqual({
+      phase: "settling",
+      direction: -1,
+      isCommitted: true,
+    });
+  });
+
+  it("should release the cooldown once the wheel goes quiet", () => {
+    expect(endSwipe({ phase: "cooldown" })).toEqual(idle);
+  });
+
+  it("should leave a settling week alone", () => {
+    const settling: SwipeState = {
+      phase: "settling",
+      direction: 1,
+      isCommitted: true,
+    };
+    expect(endSwipe(settling)).toBe(settling);
+  });
+});
+
+describe("settleSwipe", () => {
+  it("should enter the cooldown when the animation is done", () => {
+    const settling: SwipeState = {
+      phase: "settling",
+      direction: 1,
+      isCommitted: false,
+    };
+    expect(settleSwipe(settling)).toEqual({ phase: "cooldown" });
+  });
+
+  it("should leave every other phase alone", () => {
+    expect(settleSwipe(idle)).toBe(idle);
+  });
+});
+
+describe("swipePreview", () => {
+  it("should render nothing without a gesture", () => {
+    expect(swipePreview(idle)).toBeNull();
+    expect(swipePreview({ phase: "cooldown" })).toBeNull();
+  });
+
+  it("should hold the next week off the right edge and pull it in", () => {
+    expect(swipePreview(dragging(1, 0))).toEqual({
+      direction: 1,
+      translatePercent: 100,
+      isAnimating: false,
+    });
+    expect(swipePreview(dragging(1, 250))).toEqual({
+      direction: 1,
+      translatePercent: 75,
+      isAnimating: false,
+    });
+  });
+
+  it("should hold the previous week off the left edge", () => {
+    expect(swipePreview(dragging(-1, 250))).toEqual({
+      direction: -1,
+      translatePercent: -75,
+      isAnimating: false,
+    });
+  });
+
+  it("should animate a committed week all the way over the current one", () => {
+    const settling: SwipeState = {
+      phase: "settling",
+      direction: 1,
+      isCommitted: true,
+    };
+    expect(swipePreview(settling)).toEqual({
+      direction: 1,
+      translatePercent: 0,
+      isAnimating: true,
+    });
+  });
+
+  it("should animate a rejected week back off the edge it came from", () => {
+    const settling: SwipeState = {
+      phase: "settling",
+      direction: -1,
+      isCommitted: false,
+    };
+    expect(swipePreview(settling)).toEqual({
+      direction: -1,
+      translatePercent: -100,
+      isAnimating: true,
+    });
+  });
+
+  it("should not divide by a zero width", () => {
+    const state: SwipeState = {
+      phase: "dragging",
+      direction: 1,
+      offset: 0,
+      width: 0,
+    };
+    expect(swipePreview(state)).toEqual({
+      direction: 1,
+      translatePercent: 100,
+      isAnimating: false,
+    });
+  });
+});

--- a/src/app/week-swipe.ts
+++ b/src/app/week-swipe.ts
@@ -1,0 +1,123 @@
+export type SwipeDirection = -1 | 1;
+
+export type SwipeState =
+  | { phase: "idle" }
+  | {
+      phase: "dragging";
+      direction: SwipeDirection;
+      /** How far the incoming week has been pulled in, in pixels, never negative. */
+      offset: number;
+      width: number;
+    }
+  | { phase: "settling"; direction: SwipeDirection; isCommitted: boolean }
+  // The wheel keeps firing after the fingers leave the trackpad, so the tail of a
+  // finished gesture must not start the next one.
+  | { phase: "cooldown" };
+
+export const swipeCommitRatio = 0.2;
+export const swipeSettleMs = 250;
+/** How long the wheel must stay quiet for the gesture to count as finished. */
+export const swipeQuietMs = 120;
+
+const activationDelta = 2;
+const scrollEdgeTolerance = 1;
+
+export interface WheelSample {
+  deltaX: number;
+  deltaY: number;
+  scrollLeft: number;
+  scrollWidth: number;
+  clientWidth: number;
+}
+
+export interface SwipePreview {
+  direction: SwipeDirection;
+  /** Position of the incoming week relative to its own width: 100 is fully off screen, 0 fully over the current week. */
+  translatePercent: number;
+  isAnimating: boolean;
+}
+
+export function advanceSwipe(
+  state: SwipeState,
+  sample: WheelSample,
+): SwipeState {
+  if (state.phase === "settling" || state.phase === "cooldown") {
+    return state;
+  }
+  const { deltaX, deltaY } = sample;
+  if (
+    Math.abs(deltaX) < activationDelta ||
+    Math.abs(deltaX) <= Math.abs(deltaY)
+  ) {
+    return state;
+  }
+
+  if (state.phase === "dragging") {
+    return {
+      ...state,
+      offset: clamp(state.offset + deltaX * state.direction, 0, state.width),
+    };
+  }
+
+  const direction: SwipeDirection = deltaX > 0 ? 1 : -1;
+  if (!isAtEdge(sample, direction)) {
+    return state;
+  }
+  return {
+    phase: "dragging",
+    direction,
+    offset: Math.min(Math.abs(deltaX), sample.clientWidth),
+    width: sample.clientWidth,
+  };
+}
+
+export function endSwipe(state: SwipeState): SwipeState {
+  if (state.phase === "dragging") {
+    return {
+      phase: "settling",
+      direction: state.direction,
+      isCommitted: progressOf(state) >= swipeCommitRatio,
+    };
+  }
+  if (state.phase === "cooldown") {
+    return { phase: "idle" };
+  }
+  return state;
+}
+
+export function settleSwipe(state: SwipeState): SwipeState {
+  return state.phase === "settling" ? { phase: "cooldown" } : state;
+}
+
+export function swipePreview(state: SwipeState): SwipePreview | null {
+  if (state.phase === "dragging") {
+    return {
+      direction: state.direction,
+      translatePercent: state.direction * 100 * (1 - progressOf(state)),
+      isAnimating: false,
+    };
+  }
+  if (state.phase === "settling") {
+    return {
+      direction: state.direction,
+      translatePercent: state.isCommitted ? 0 : state.direction * 100,
+      isAnimating: true,
+    };
+  }
+  return null;
+}
+
+function progressOf(state: { offset: number; width: number }): number {
+  return state.width > 0 ? clamp(state.offset / state.width, 0, 1) : 0;
+}
+
+function isAtEdge(sample: WheelSample, direction: SwipeDirection): boolean {
+  return direction === 1
+    ? sample.scrollLeft >=
+        sample.scrollWidth - sample.clientWidth - scrollEdgeTolerance
+    : sample.scrollLeft <= scrollEdgeTolerance;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}


### PR DESCRIPTION
## Description

A horizontal two-finger trackpad swipe on the planning grid pulls the neighbouring week in from the side the swipe comes from.
The incoming week is drawn over the current one rather than pushing it aside, and follows the fingers one to one.
Pulled in by at least 20 percent of the grid width it slides the rest of the way and becomes the displayed week, below that it slides back out and the displayed week stays.

The incoming week renders from the assignment cache, so the neighbouring weeks the planning view already prefetches show their cards during the gesture.
A week without cached assignments arrives as a bare grid with that week's day headers and fills in once its load finishes.

### Notable decisions

The gesture reads `wheel` events rather than pointer drags, because a two-finger trackpad swipe is what the macOS app gets and it needs no separation from the existing dnd-kit appointment drag.

A grid too wide for the window keeps scrolling horizontally first.
The gesture starts only from a swipe that continues past the scroll edge it is heading for, and the incoming week is offset to the same `scrollLeft` so the columns do not jump on handover.

The wheel stays claimed until the input goes quiet, so the momentum after a flick cannot chain a second week change.
While an assignment card is being dragged the swipe is suppressed entirely, since edge hovering already navigates weeks there.

The incoming week's copy of the table gets its own dnd context and the panel is `inert` with `pointer-events-none`, so the copy never becomes a drop target, never takes focus, and never swallows the wheel events that drive the gesture.

The week's table moved into `week-table.tsx` so the live grid and the incoming copy render from the same markup.
Holidays are not prefetched for the neighbouring week, so holiday markers appear only after the week change, the same way uncached events do.

### What to look out for

Whether 20 percent and the 250 ms settle feel right on a real trackpad, and whether the momentum cooldown is long enough that a hard flick reliably advances exactly one week.

### Screenshots / evidence of successful implementation

`bun test` passes with 325 tests, `tsc --noEmit` and `biome check` are clean.
The app was additionally driven in Chromium with the Tauri IPC stubbed and real wheel events: a partial pull snaps back to the same week, a full pull commits to the next week, a reverse swipe returns, vertical and mostly-vertical scrolling is unaffected, and at a 480 px window the grid scrolls its 74 px of horizontal overflow before the swipe engages.

## Reviewer checklist

- [x] Swipe left and right on the grid with a trackpad and confirm the neighbouring week is pulled in with its already loaded events
- [x] Confirm a short swipe snaps back to the current week and a swipe past a fifth of the width changes the week
- [x] Confirm a hard flick advances exactly one week
- [x] Confirm vertical scrolling in a grid taller than the window still works and does not change the week
- [x] Narrow the window until the grid scrolls horizontally, then confirm it scrolls to the edge before the week gesture starts
- [x] Drag an assignment card and confirm the swipe does nothing while the drag runs, and that edge hovering still navigates
