### PR TITLE
Add OpenSpec change for PostHog telemetry

### DIFF
--- a/openspec/changes/telemetry-error-and-performance-posthog/.openspec.yaml
+++ b/openspec/changes/telemetry-error-and-performance-posthog/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-07

--- a/openspec/changes/telemetry-error-and-performance-posthog/design.md
+++ b/openspec/changes/telemetry-error-and-performance-posthog/design.md
@@ -1,0 +1,119 @@
+## Context
+
+See proposal.md - Why for the motivation.
+
+Constraints that shape the approach:
+
+- CLAUDE.md requires all third-party API logic to live in the Rust backend, so the PostHog client cannot be a frontend SDK; the frontend reports errors through a Tauri command.
+- Errors already travel as structured payloads (`StoreError`, `ZepError`, and siblings) carrying `code`, `user_message`, and `technical_message`, so an event taxonomy can reuse `code` as an enumerated dimension without inventing one.
+- Failure sites today are `eprintln!` calls in `daylite/projects.rs`, `calendar/caldav/write.rs`, `calendar/protection.rs`, `holidays.rs`, and `lib.rs`; these are the natural instrumentation points.
+- `uuid` (v4), `reqwest` (via `tauri-plugin-http`), `tokio`, `serde`, and `chrono` are already dependencies, so no new crate is required.
+- The repository has a record/replay HTTP harness (`integrations/http_record_replay.rs`) used for integration tests, which the capture request can reuse.
+- PostHog's free tier allows one million events per month, which bounds how finely operations may be instrumented.
+- The application and its users are German, so the EU-hosted PostHog region is the appropriate target.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One instrumentation helper that wraps an operation and emits both its duration and its failure, so a call site is annotated once rather than twice.
+- A single redaction boundary that every outbound event passes through, so data minimization is enforced structurally instead of by reviewer discipline.
+- Telemetry that is inert by construction in tests, local development, and builds without a project key.
+
+**Non-Goals:**
+
+- No session replay, autocapture, feature flags, or PostHog product analytics features beyond event capture.
+- No crash reporting for hard process aborts (a panic that kills the process is out of reach for an in-process buffer); only recoverable errors and caught panics are covered.
+- No local log file, log viewer, or in-app diagnostics export.
+- No per-user identification or PostHog person profiles beyond the anonymous install identifier.
+
+## Decisions
+
+### Opt-in consent, stored in the local store
+
+Telemetry defaults to off and requires an explicit user action to enable, with the flag persisted in `LocalStore` under a `telemetry` section behind `#[serde(default)]`.
+
+This is an assumption made without confirmation from the user, chosen because the app processes German business data and an opt-in default is the position that needs no further legal argument.
+The alternative, opt-out with a first-run notice, produces far better coverage and remains defensible under legitimate interest, but it requires a consent notice and a documented basis, which is a larger surface than this change should decide unilaterally.
+Switching later is a one-line default change plus the notice, so the cheap direction is to start opt-in.
+
+The flag lives in the local store rather than the keychain because it is a preference, not a secret.
+
+### Backend-only PostHog client with a build-time key
+
+A `telemetry` module in `src-tauri/src/integrations/` owns the only code that knows the PostHog endpoint, reading the project key from `option_env!("POSTHOG_API_KEY")` at compile time.
+When the variable is absent the module compiles to an inert client that records nothing, which makes local development and the test suite silent without a runtime guard at every call site.
+
+Bundling the key in the binary is acceptable because a PostHog project API key is a write-only ingestion key intended for client distribution; it grants no read access to captured data.
+
+The target is the EU region endpoint (`https://eu.i.posthog.com/batch/`) so that event data stays in the EU.
+The alternative, the US region default, would add a transfer question that the EU region simply avoids.
+
+### One `observe` helper at the operation boundary
+
+Instrumentation is a single async helper that takes an operation name and a future, measures elapsed time, inspects the result, and emits a performance event plus, on failure, an error event.
+
+```
+telemetry::observe(Operation::LoadWeekEvents, async { ... }).await
+```
+
+Each Tauri command body is wrapped once, and outbound request helpers per integration are wrapped once.
+The alternative, a procedural macro over the specta command list, would instrument every command automatically but hides control flow and cannot express the integration-level request events, which are the more diagnostic half.
+Sprinkling separate `record_duration` and `record_error` calls was rejected because the two drift apart the moment a call site gains an early return.
+
+`Operation` is an enum, not a string, so the event dimension stays a closed set and a typo cannot create a new one in PostHog.
+
+### Redaction as a constructor invariant
+
+Event payloads are built only through constructors that run every free-text field through a sanitizer stripping URLs, file paths, bearer tokens, and e-mail addresses before the value is stored on the event.
+The raw `technical_message` never reaches an event field unsanitized, so a new call site cannot leak by forgetting to sanitize.
+
+Structured dimensions (integration, operation, error code, HTTP status, duration) are typed and carry no free text at all.
+The alternative, sanitizing at serialization time, was rejected because it invites a future "just this once" field that bypasses the serializer path.
+
+### Bounded queue with a background flush task
+
+Recording sends the event over a bounded `tokio::sync::mpsc` channel and returns immediately; a background task owns the buffer and flushes on whichever comes first, a thirty second interval or twenty buffered events.
+When the channel is full the event is dropped at the sender, which keeps a telemetry stall from applying back-pressure to a user-facing command.
+The buffer caps at five hundred events and drops oldest-first, bounding memory during a long offline stretch.
+
+A failed batch is retried on the next flush tick and then dropped rather than retried with backoff, because stale duration measurements have little diagnostic value and a persistent retry queue is more machinery than the problem warrants.
+
+On `RunEvent::Exit` the task gets a bounded window of two seconds to send what it holds, so shutdown is not visibly delayed.
+
+### Event volume within the free tier
+
+Two event names carry everything: `operation_completed` (with `success`, `duration_ms`, `operation`, `integration`) and `error_occurred` (with `operation`, `integration`, `code`, `message`), plus `app_started` once per launch.
+
+The estimate that keeps this inside the free tier: a planner performing roughly five hundred instrumented operations per working day, across ten installs, produces about one hundred thousand events per month, an order of magnitude under the one million limit.
+Nothing per-render, per-keystroke, or per-drag-frame is instrumented, which is what would break that estimate.
+Reporting both success and failure durations under one event name, rather than separate names per operation, keeps PostHog insights groupable by dimension instead of requiring a new insight per operation.
+
+### Frontend errors travel through a command
+
+A React error boundary at the application root plus `window.addEventListener` handlers for `error` and `unhandledrejection` forward to a `telemetry_capture_frontend_error` Tauri command.
+The frontend therefore never holds the PostHog key or endpoint, satisfying the CLAUDE.md rule that third-party API logic stays in the backend, and frontend events pass through the same redaction and consent gate as backend events.
+
+The error boundary renders a German fallback message, so an uncaught render error degrades to a readable screen rather than a blank one.
+
+## Risks / Trade-offs
+
+- [Opt-in default means most installs report nothing, so the data may be too sparse to spot a regression] → Accept for now; the settings copy explains the benefit, and the default can be revisited once the legal basis for opt-out is settled.
+- [A new call site adds a free-text field that leaks business data] → Constructors sanitize on entry, and a unit test asserts that a technical message containing a URL, a path, and a token comes out redacted.
+- [The PostHog key is extractable from the shipped binary] → Accepted; the key is write-only ingestion and cannot read captured data. A leaked key permits event spam into the project, which is recoverable by rotating it.
+- [Instrumentation noise in command bodies obscures the domain logic] → One wrapping call per command, with the enum and helper in the telemetry module, keeps the diff at the boundary rather than inside the logic.
+- [Duration measurements include cache hits and therefore mix two populations] → The performance event carries the operation name only; distinguishing a cached from an uncached load is left to a later change if the data proves ambiguous.
+- [A misconfigured build could point telemetry at the wrong project] → The key is absent by default and telemetry is inert without it, so the failure mode is silence rather than misdirected data.
+
+## Migration Plan
+
+- Ship the local store field first, behind `#[serde(default)]`, so existing store files load unchanged and report telemetry as disabled.
+- Build the telemetry module with its tests before wiring any call site, following the red/green order CLAUDE.md requires.
+- Wire the consent panel next, so the flag is reachable before any event can be produced.
+- Instrument call sites last, one integration at a time, since each is independent and none changes observable behavior.
+- Rollback is reverting the commits; no data migration is involved, and an unknown `telemetry` key in a store file written by a newer build is ignored by older builds through the same `serde(default)` handling.
+- Set `POSTHOG_API_KEY` in the release build workflow only, leaving development and CI builds inert.
+
+## Open Questions
+
+- Which retention window and project settings to configure in the PostHog project itself; this is a dashboard-side setting that does not affect the specs, the client, or the task breakdown.

--- a/openspec/changes/telemetry-error-and-performance-posthog/proposal.md
+++ b/openspec/changes/telemetry-error-and-performance-posthog/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The application currently reports failures only through `eprintln!` in the Rust backend and German error strings in the UI, so nobody outside the running machine ever learns that a Daylite refresh failed, a CalDAV write was rejected, or a week load took twelve seconds.
+Because this is a distributed desktop app, there is no server log to inspect after a user reports "es hängt" — the evidence is gone by the time the report arrives.
+Sending structured error and duration events to PostHog (free tier) makes recurring integration failures and slow operations visible per release without a support ticket.
+
+## What Changes
+
+- Add a `telemetry` capability in the Rust backend that buffers events and sends them to the PostHog capture API in batches, with the project API key baked in at build time.
+- Capture error events for failed Tauri commands and failed outbound integration calls (Daylite, ZEP/CalDAV, Nager holidays, local store, keychain), carrying the existing error `code`, the integration name, and the technical message.
+- Capture error events for uncaught frontend errors and unhandled promise rejections via a React error boundary and global handlers.
+- Capture performance events measuring the duration of Tauri commands, outbound HTTP calls to each integration, and app startup.
+- Attach anonymous context to every event: app version, OS and version, and a locally generated random install ID persisted in the local store.
+- Add an opt-in telemetry consent flag, off by default, exposed as a new "Diagnose" section in the settings dialog; no event is buffered or sent while it is off.
+- Never include personal or business data in events: no project names, contact names, calendar URLs, tokens, or free-text search input — only enumerated codes, integration names, durations, and sanitized technical messages.
+- Fail silently and never block the user: telemetry delivery errors are dropped, the buffer is bounded, and no UI depends on a capture result.
+
+## Capabilities
+
+### New Capabilities
+
+- `telemetry`: Opt-in collection and delivery of error and performance events to PostHog, covering the consent gate, event taxonomy and payload shape, anonymous install identity, batching and delivery behavior, data minimization rules, and failure isolation.
+
+### Modified Capabilities
+
+- `local-store`: The persisted store gains a telemetry section holding the opt-in flag and the anonymous install ID, so consent and identity survive restarts.
+
+## Impact
+
+- `src-tauri/src/integrations/telemetry/`: new module with the PostHog client, event queue, background flush task, event types, and the redaction rules.
+- `src-tauri/src/lib.rs`: register telemetry state and the new Tauri commands, start the flush task in `setup`, and record app startup duration.
+- `src-tauri/src/integrations/local_store/types.rs`: new `TelemetrySettings` field (`enabled`, `installId`) with a default that keeps telemetry off for existing stores.
+- `src-tauri/src/integrations/{daylite,calendar,zep,holidays}`: emit error and duration events at the existing failure and request sites that today only `eprintln!`.
+- `src/app/components/settings/`: new `telemetry-panel.tsx` plus a "Diagnose" entry in `settings-dialog.tsx`.
+- `src/app/`: new error boundary and global `error`/`unhandledrejection` handlers forwarding to the backend.
+- `src/generated/tauri.ts`: regenerated specta bindings for the new commands.
+- Build/CI: a `POSTHOG_API_KEY` build-time environment variable; when it is absent the telemetry client is inert, so local dev and tests send nothing.
+- Tests: Rust unit tests for consent gating, redaction, batching, and bounded buffering; cassette-based tests for the capture request; frontend tests for the consent panel and error boundary.
+- `docs/adr/0013-telemetry-and-posthog-integration.md`: new ADR recording the opt-in model, the backend-only client, and the data-minimization rules.

--- a/openspec/changes/telemetry-error-and-performance-posthog/specs/local-store/spec.md
+++ b/openspec/changes/telemetry-error-and-performance-posthog/specs/local-store/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Persisted Telemetry Preference
+The system SHALL persist the telemetry opt-in flag and the anonymous install identifier in the local store, and SHALL default the flag to disabled when it is absent.
+
+#### Scenario: Telemetry preference persisted
+- **GIVEN** the user changes the telemetry setting
+- **WHEN** the local store is saved and reloaded
+- **THEN** the restored configuration reports the same telemetry state
+
+#### Scenario: Store written before telemetry existed
+- **GIVEN** a stored configuration file without a telemetry section
+- **WHEN** the local store is loaded
+- **THEN** loading succeeds without error
+- **AND** telemetry is reported as disabled
+
+#### Scenario: Install identifier persisted
+- **GIVEN** an install identifier has been generated
+- **WHEN** the local store is saved and reloaded
+- **THEN** the restored configuration reports the same identifier

--- a/openspec/changes/telemetry-error-and-performance-posthog/specs/telemetry/spec.md
+++ b/openspec/changes/telemetry-error-and-performance-posthog/specs/telemetry/spec.md
@@ -1,0 +1,184 @@
+## Purpose
+
+Make failures and slow operations in a distributed desktop app observable to the maintainer by sending anonymous, opt-in error and performance events to PostHog, without ever transmitting personal or business data.
+
+## ADDED Requirements
+
+### Requirement: Opt-in consent gate
+The system SHALL treat telemetry as disabled unless the user has explicitly enabled it, and SHALL neither record nor transmit any event while telemetry is disabled.
+
+#### Scenario: Telemetry off on first launch
+- **GIVEN** the application is started with no stored telemetry preference
+- **WHEN** an error occurs or an operation completes
+- **THEN** no event is recorded and no request is sent to the telemetry endpoint
+
+#### Scenario: Existing installation keeps telemetry off
+- **GIVEN** a stored configuration written before telemetry existed
+- **WHEN** the configuration is loaded
+- **THEN** telemetry is reported as disabled
+- **AND** no event is recorded until the user enables it
+
+#### Scenario: User enables telemetry
+- **GIVEN** telemetry is disabled
+- **WHEN** the user enables telemetry in the settings dialog
+- **THEN** the preference is persisted
+- **AND** subsequent errors and completed operations are recorded
+
+#### Scenario: User disables telemetry
+- **GIVEN** telemetry is enabled and events are pending delivery
+- **WHEN** the user disables telemetry
+- **THEN** the preference is persisted
+- **AND** all pending events are discarded without being sent
+- **AND** no further events are recorded
+
+### Requirement: Anonymous install identity
+The system SHALL identify events by a randomly generated install identifier that contains no user, device, or account information, and SHALL keep that identifier stable across restarts of the same installation.
+
+#### Scenario: Identifier generated on first activation
+- **GIVEN** telemetry is enabled and no install identifier exists
+- **WHEN** the first event is recorded
+- **THEN** a random identifier is generated and persisted
+- **AND** the event carries that identifier
+
+#### Scenario: Identifier stable across restarts
+- **GIVEN** an install identifier has been persisted
+- **WHEN** the application is restarted and an event is recorded
+- **THEN** the event carries the same identifier
+
+#### Scenario: Identifier is not derived from user data
+- **WHEN** an install identifier is generated
+- **THEN** it is a random value
+- **AND** it is not derived from user name, host name, e-mail address, account data, or hardware identifiers
+
+### Requirement: Error events
+The system SHALL record an error event when a backend operation fails, when an outbound request to an integration fails, and when the user interface encounters an uncaught error.
+
+#### Scenario: Backend command fails
+- **GIVEN** telemetry is enabled
+- **WHEN** a backend command returns a structured error
+- **THEN** an error event is recorded carrying the operation name, the integration name, the error code, and a sanitized technical message
+
+#### Scenario: Outbound integration request fails
+- **GIVEN** telemetry is enabled
+- **WHEN** a request to Daylite, the ZEP CalDAV server, or the holiday API fails or returns an unsuccessful status
+- **THEN** an error event is recorded carrying the integration name, the request kind, and the response status when one was received
+
+#### Scenario: Uncaught frontend error
+- **GIVEN** telemetry is enabled
+- **WHEN** a rendering error or an unhandled promise rejection occurs in the user interface
+- **THEN** an error event is recorded carrying the error name, a sanitized message, and the component or handler context
+
+#### Scenario: Error is still shown to the user
+- **WHEN** an error event is recorded
+- **THEN** the German user-facing error message is displayed unchanged
+- **AND** the displayed message does not depend on the outcome of telemetry recording
+
+### Requirement: Performance events
+The system SHALL record the measured duration of backend commands, outbound integration requests, and application startup.
+
+#### Scenario: Backend command duration
+- **GIVEN** telemetry is enabled
+- **WHEN** a backend command completes, successfully or with an error
+- **THEN** a performance event is recorded carrying the operation name, the duration in milliseconds, and whether the operation succeeded
+
+#### Scenario: Outbound request duration
+- **GIVEN** telemetry is enabled
+- **WHEN** a request to an integration completes
+- **THEN** a performance event is recorded carrying the integration name, the request kind, the duration in milliseconds, and the response status when one was received
+
+#### Scenario: Startup duration
+- **GIVEN** telemetry is enabled
+- **WHEN** the application finishes starting up
+- **THEN** a performance event is recorded carrying the duration from process start to the ready state
+
+### Requirement: Event context
+The system SHALL attach the application version, the operating system name and version, and the install identifier to every transmitted event.
+
+#### Scenario: Context present on every event
+- **GIVEN** telemetry is enabled
+- **WHEN** any event is transmitted
+- **THEN** it carries the application version, the operating system name and version, and the install identifier
+
+#### Scenario: Events distinguishable per release
+- **GIVEN** events recorded from two different application versions
+- **WHEN** the events are inspected
+- **THEN** each event's application version identifies the release it came from
+
+### Requirement: Data minimization
+The system SHALL restrict event payloads to enumerated identifiers, numeric measurements, and sanitized technical messages, and SHALL NOT transmit personal or business data.
+
+#### Scenario: Business data excluded
+- **WHEN** an event is built for any operation
+- **THEN** it contains no project name, contact name, employee name, appointment title, or note text
+
+#### Scenario: Credentials and endpoints excluded
+- **WHEN** an event is built for a failed request
+- **THEN** it contains no token, password, authorization header, calendar URL, or query string
+
+#### Scenario: Free-text input excluded
+- **WHEN** a project search fails or is measured
+- **THEN** the event contains no search term entered by the user
+
+#### Scenario: Technical message sanitized
+- **GIVEN** a technical error message that embeds a URL, a file path, or a token
+- **WHEN** the error event is built
+- **THEN** the embedded value is redacted from the transmitted message
+- **AND** the surrounding error description is retained
+
+### Requirement: Batched delivery
+The system SHALL buffer recorded events and transmit them in batches to the telemetry endpoint, in the background, without blocking the operation that produced them.
+
+#### Scenario: Events sent in batches
+- **GIVEN** telemetry is enabled and several events have been recorded
+- **WHEN** the flush interval elapses or the batch size is reached
+- **THEN** the buffered events are transmitted in a single request
+- **AND** transmitted events are removed from the buffer
+
+#### Scenario: Recording does not block the caller
+- **WHEN** an event is recorded during a user-facing operation
+- **THEN** the operation returns without waiting for the event to be transmitted
+
+#### Scenario: Pending events flushed on shutdown
+- **GIVEN** telemetry is enabled and events are buffered
+- **WHEN** the application shuts down
+- **THEN** a final delivery attempt is made within a bounded time
+- **AND** shutdown is not delayed beyond that bound if delivery does not complete
+
+### Requirement: Failure isolation
+The system SHALL contain all telemetry failures within the telemetry path, so that no telemetry condition degrades or interrupts the planning workflow.
+
+#### Scenario: Telemetry endpoint unreachable
+- **GIVEN** telemetry is enabled and the endpoint cannot be reached
+- **WHEN** a delivery attempt fails
+- **THEN** the failure is not surfaced to the user
+- **AND** the planning workflow continues unaffected
+
+#### Scenario: Buffer bounded when offline
+- **GIVEN** telemetry is enabled and delivery has been failing
+- **WHEN** the number of buffered events reaches the configured limit
+- **THEN** the oldest events are dropped
+- **AND** memory use stays bounded
+
+#### Scenario: No telemetry key configured
+- **GIVEN** the application was built without a telemetry project key
+- **WHEN** telemetry is enabled and an event is recorded
+- **THEN** no request is sent to any endpoint
+- **AND** the application behaves as if telemetry were disabled
+
+### Requirement: Consent visibility
+The system SHALL expose the telemetry preference in the settings dialog with a German description of what is collected.
+
+#### Scenario: Telemetry setting reachable
+- **WHEN** the user opens the settings dialog
+- **THEN** a section for diagnostics is listed
+- **AND** it contains a control to enable or disable telemetry
+
+#### Scenario: Collection described in German
+- **WHEN** the diagnostics section is shown
+- **THEN** it states in German that anonymous error and performance data is transmitted
+- **AND** it states that no project, contact, or login data is transmitted
+
+#### Scenario: Current state reflected
+- **GIVEN** telemetry is enabled
+- **WHEN** the user reopens the settings dialog
+- **THEN** the control shows telemetry as enabled

--- a/openspec/changes/telemetry-error-and-performance-posthog/tasks.md
+++ b/openspec/changes/telemetry-error-and-performance-posthog/tasks.md
@@ -1,0 +1,91 @@
+## 1. Local store telemetry settings
+
+- [ ] 1.1 Write failing `cargo test`s in `src-tauri/src/integrations/local_store/types.rs`: telemetry defaults to disabled, a store file without a `telemetry` section loads without error, and the install identifier round-trips through save and reload
+- [ ] 1.2 Add `TelemetrySettings { enabled: bool, install_id: Option<String> }` to `LocalStore` behind `#[serde(default)]`, satisfying the tests
+- [ ] 1.3 Run `cargo test` in `src-tauri` and confirm the existing local store tests still pass
+
+## 2. Telemetry module foundation
+
+- [ ] 2.1 Create `src-tauri/src/integrations/telemetry/mod.rs` and register it in `integrations/mod.rs`
+- [ ] 2.2 Write failing tests for the `Operation` and `Integration` enums serializing to stable snake_case dimension values
+- [ ] 2.3 Implement `events.rs` with the `Operation` and `Integration` enums and the `operation_completed` / `error_occurred` / `app_started` event structs, satisfying the tests
+- [ ] 2.4 Write failing tests for the redaction sanitizer: a message containing a URL, an absolute file path, a bearer token, and an e-mail address comes out with each value redacted and the surrounding description retained
+- [ ] 2.5 Implement `redact.rs` and make the event constructors the only way to build an event, running every free-text field through the sanitizer
+- [ ] 2.6 Write a failing test asserting that an event built from a `ZepError` whose technical message embeds a calendar URL transmits no URL
+- [ ] 2.7 Satisfy that test and confirm structured dimensions carry no free text
+
+## 3. Consent gate and install identity
+
+- [ ] 3.1 Write failing tests: no event is recorded while telemetry is disabled, events are recorded once enabled, and disabling discards pending events
+- [ ] 3.2 Implement the consent gate in the telemetry recorder, reading the flag from the local store, satisfying the tests
+- [ ] 3.3 Write failing tests: an install identifier is generated on first activation, is stable across reloads, and is a random `uuid` v4 rather than derived from user or host data
+- [ ] 3.4 Implement install identifier generation and persistence, satisfying the tests
+
+## 4. Buffering and delivery
+
+- [ ] 4.1 Write failing tests for the bounded buffer: events flush at twenty buffered events, flush on the interval tick, drop oldest-first at the five hundred event cap, and recording returns without awaiting delivery
+- [ ] 4.2 Implement `queue.rs` with the bounded `tokio::sync::mpsc` channel and the background flush task, satisfying the tests
+- [ ] 4.3 Write a failing test asserting the client is inert when `POSTHOG_API_KEY` is absent at compile time (no request attempted)
+- [ ] 4.4 Implement `client.rs` posting batches to the EU `/batch/` endpoint with the `option_env!` key, satisfying the test
+- [ ] 4.5 Add a cassette-based test for the capture request using the existing `http_record_replay` harness, asserting the batch payload shape and that `distinct_id` is the install identifier
+- [ ] 4.6 Write a failing test asserting a failed delivery attempt is not surfaced to the caller and the buffer stays bounded
+- [ ] 4.7 Implement drop-after-one-retry delivery failure handling, satisfying the test
+
+## 5. Event context
+
+- [ ] 5.1 Write failing tests asserting every transmitted event carries the app version, the OS name and version, and the install identifier
+- [ ] 5.2 Implement context enrichment applied at batch build time, satisfying the tests
+
+## 6. Tauri wiring
+
+- [ ] 6.1 Add `telemetry_get_settings` and `telemetry_set_enabled` commands and register them in the specta builder in `src-tauri/src/lib.rs`
+- [ ] 6.2 Add the `telemetry_capture_frontend_error` command accepting error name, message, and context, routing through the same redaction and consent gate
+- [ ] 6.3 Initialize telemetry state and spawn the flush task in the Tauri `setup` hook
+- [ ] 6.4 Emit the `app_started` event with the startup duration measured from process start to the ready state
+- [ ] 6.5 Add a bounded two second final flush on `RunEvent::Exit`
+- [ ] 6.6 Run `cargo test` to regenerate `src/generated/tauri.ts` via the bindings test and confirm the new commands appear
+
+## 7. Consent UI
+
+- [ ] 7.1 Write failing tests in `src/app/components/settings/telemetry-panel.spec.tsx`: the toggle reflects the stored state, toggling persists via the command, and the German description names what is and is not transmitted
+- [ ] 7.2 Implement `telemetry-panel.tsx` with the DaisyUI toggle and the German description, satisfying the tests
+- [ ] 7.3 Add the "Diagnose" section to `sections` in `settings-dialog.tsx` and render the panel
+- [ ] 7.4 Update `settings-dialog` tests for the new section
+
+## 8. Frontend error capture
+
+- [ ] 8.1 Write failing tests for the root error boundary: a child render error reports through the telemetry command and a German fallback message is displayed
+- [ ] 8.2 Implement the error boundary and mount it at the application root in `src/app/page.tsx`
+- [ ] 8.3 Write failing tests for the global `error` and `unhandledrejection` handlers forwarding to the telemetry command
+- [ ] 8.4 Implement the global handlers, satisfying the tests
+- [ ] 8.5 Verify no frontend module references the PostHog endpoint or key
+
+## 9. Backend instrumentation
+
+- [ ] 9.1 Implement the `telemetry::observe(Operation, future)` helper with tests covering success, failure, and that the measured duration is emitted in both cases
+- [ ] 9.2 Wrap the calendar commands in `calendar/commands.rs` (`load_week_events`, `create_assignment`, `update_assignment`, `move_assignment`, `reorder_assignment`, `delete_assignment`)
+- [ ] 9.3 Instrument the CalDAV request sites in `calendar/caldav/`, replacing the `eprintln!` failure logs in `write.rs` and `protection.rs` with telemetry events plus the existing log where it still aids local debugging
+- [ ] 9.4 Instrument the Daylite request sites in `daylite/client.rs`, `projects.rs`, `categories.rs`, and `contacts/`, ensuring no search term or project name enters an event
+- [ ] 9.5 Instrument the ZEP commands and credential loading in `zep/`, ensuring no calendar URL or password enters an event
+- [ ] 9.6 Instrument the holiday API request in `holidays.rs`, replacing its four `eprintln!` failure paths
+- [ ] 9.7 Instrument local store read and write failures with the existing `StoreErrorCode` as the error dimension
+
+## 10. Build configuration
+
+- [ ] 10.1 Wire `POSTHOG_API_KEY` into the release build workflow only, leaving development and CI builds without it
+- [ ] 10.2 Confirm a build without the variable produces an inert client and a passing test suite
+
+## 11. Documentation
+
+- [ ] 11.1 Write `docs/adr/0013-telemetry-and-posthog-integration.md` recording the opt-in default, the backend-only client, the EU region choice, and the data minimization rules
+- [ ] 11.2 Add telemetry to the README implemented-features list
+- [ ] 11.3 Run `bun run test:docs`
+
+## 12. Verification
+
+- [ ] 12.1 Run `cargo test` in `src-tauri` and confirm all tests pass
+- [ ] 12.2 Run `bun test` and confirm all tests pass
+- [ ] 12.3 Run `bun lint` and fix any issues
+- [ ] 12.4 Manually verify with telemetry disabled that no outbound request reaches the telemetry endpoint
+- [ ] 12.5 Manually verify with telemetry enabled against a scratch PostHog project that a forced Daylite failure and a week load appear as `error_occurred` and `operation_completed` events carrying no personal or business data
+- [ ] 12.6 Run `bunx openspec validate telemetry-error-and-performance-posthog --strict`


### PR DESCRIPTION
## Description

Planning artifacts only, no implementation.
This adds the OpenSpec change `telemetry-error-and-performance-posthog`, which plans opt-in error and performance telemetry sent to PostHog from the Rust backend.

Today failures only reach `eprintln!` and German UI strings, so nothing survives past the user's machine.
The change covers a consent gate, anonymous install identity, the event taxonomy, batched delivery, data minimization, and failure isolation.

Artifacts: `proposal.md`, `specs/telemetry/spec.md`, `specs/local-store/spec.md`, `design.md`, `tasks.md`.
`bunx openspec validate telemetry-error-and-performance-posthog --strict` passes.

### Notable decisions

Telemetry is opt-in and off by default.
This is an assumption I made without confirmation, and it is flagged as such in `design.md`.
Opt-out would give much better coverage and stays defensible under legitimate interest, but it needs a consent notice and a documented legal basis, so the cheaper direction is to start opt-in and revisit.

The PostHog client lives entirely in the Rust backend, per the CLAUDE.md rule that third-party API logic stays there.
The frontend reports errors through a Tauri command and never holds the endpoint or key.

The project key is read via `option_env!("POSTHOG_API_KEY")` at compile time, so development and CI builds are inert by construction rather than by a runtime guard at each call site.

Events go to the EU region endpoint so captured data stays in the EU.

Instrumentation is a single `telemetry::observe(Operation, future)` wrapper that emits both the duration and, on failure, the error.
Separate duration and error calls were rejected because they drift apart as soon as a call site gains an early return.

Redaction runs inside the event constructors rather than at serialization time, so a new call site cannot leak by forgetting to sanitize.

Scope is errors and performance only.
Product usage tracking was left out as outside the request and per YAGNI.

### What to look out for

The opt-in default is the main thing to confirm or overrule, since it determines how much data this actually yields.

The free tier budget assumes roughly 100k events per month across about 10 installs.
That estimate breaks if anything per-render, per-keystroke, or per-drag-frame gets instrumented later.

The PostHog project key will be extractable from the shipped binary.
That is accepted in the design: it is a write-only ingestion key that grants no read access to captured data, and a leak is recoverable by rotating it.

Task group 9 touches every integration to replace existing `eprintln!` failure paths, so it is the widest part of the eventual implementation diff.

## Reviewer checklist

- [x] Confirm or overrule the opt-in default in `design.md` under "Opt-in consent, stored in the local store"
- [x] Check the data minimization requirements in `specs/telemetry/spec.md` cover everything that must never leave the machine
- [x] Confirm the event taxonomy in `design.md` under "Event volume within the free tier" supports the insights you would actually want
- [x] Run `bunx openspec validate telemetry-error-and-performance-posthog --strict`
