### PR TITLE
Refresh today highlight when the day changes

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -20,7 +20,6 @@ import { loadDayliteContacts } from "./services/daylite-contacts";
 function App() {
   const [weekOffset, setWeekOffset] = useState(0);
   const [showWeekend, setShowWeekend] = useState(false);
-  // Week and today highlight are derived from the current date at render time.
   useRerenderOnDayChange();
   const weekStart = getWeekStart(weekOffset, showWeekend);
   const planningAssignmentsState = usePlanningAssignments(weekStart);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,6 +8,7 @@ import { usePlanningAssignments } from "./app/hooks/use-planning-assignments";
 import { usePlanningEmployees } from "./app/hooks/use-planning-employees";
 import { useProjectCategoryColors } from "./app/hooks/use-project-category-colors";
 import { useReloadDataMenu } from "./app/hooks/use-reload-data-menu";
+import { useRerenderOnDayChange } from "./app/hooks/use-rerender-on-day-change";
 import { useZepCalendars } from "./app/hooks/use-zep-calendars";
 import { PlanningGrid } from "./app/page";
 import { getWeekStart } from "./app/util";
@@ -19,6 +20,8 @@ import { loadDayliteContacts } from "./services/daylite-contacts";
 function App() {
   const [weekOffset, setWeekOffset] = useState(0);
   const [showWeekend, setShowWeekend] = useState(false);
+  // Week and today highlight are derived from the current date at render time.
+  useRerenderOnDayChange();
   const weekStart = getWeekStart(weekOffset, showWeekend);
   const planningAssignmentsState = usePlanningAssignments(weekStart);
   const planningEmployeesState = usePlanningEmployees();

--- a/src/app/hooks/use-rerender-on-day-change.ts
+++ b/src/app/hooks/use-rerender-on-day-change.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import { millisecondsUntilNextLocalMidnight, toLocalISODate } from "../util";
+
+export function useRerenderOnDayChange(): void {
+  const [, setToday] = useState(() => toLocalISODate(new Date()));
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+
+    const scheduleNextDay = () => {
+      const now = new Date();
+      timer = setTimeout(() => {
+        setToday(toLocalISODate(new Date()));
+        scheduleNextDay();
+      }, millisecondsUntilNextLocalMidnight(now));
+    };
+
+    scheduleNextDay();
+    return () => clearTimeout(timer);
+  }, []);
+}

--- a/src/app/util.spec.ts
+++ b/src/app/util.spec.ts
@@ -11,6 +11,7 @@ import {
   getWeekDays,
   getWeekStart,
   isToday,
+  millisecondsUntilNextLocalMidnight,
   shiftWeekDays,
   toLocalISODate,
 } from "./util";
@@ -206,6 +207,37 @@ describe("util", () => {
       expect(isToday(new Date(2026, 1, 1, 12, 34, 56))).toBe(false);
       expect(isToday(new Date(2026, 0, 2, 12, 34, 56))).toBe(false);
       expect(isToday(new Date(1970, 0, 1))).toBe(false);
+    });
+  });
+
+  describe("millisecondsUntilNextLocalMidnight", () => {
+    it("counts the time left in the current local day", () => {
+      expect(
+        millisecondsUntilNextLocalMidnight(new Date(2026, 0, 1, 23, 59, 59)),
+      ).toBe(1000);
+    });
+
+    it("lands on the next local midnight, DST switches included", () => {
+      for (const start of [
+        new Date(2026, 0, 1, 12, 34, 56),
+        new Date(2026, 2, 29, 0, 0, 0),
+        new Date(2026, 9, 25, 0, 0, 0),
+      ]) {
+        const next = new Date(
+          start.getTime() + millisecondsUntilNextLocalMidnight(start),
+        );
+        expect(toLocalISODate(next)).toBe(
+          toLocalISODate(
+            new Date(
+              start.getFullYear(),
+              start.getMonth(),
+              start.getDate() + 1,
+            ),
+          ),
+        );
+        expect(next.getHours()).toBe(0);
+        expect(next.getMinutes()).toBe(0);
+      }
     });
   });
 });

--- a/src/app/util.ts
+++ b/src/app/util.ts
@@ -28,6 +28,15 @@ export function shiftWeekDays(days: Date[], weekOffset: number): Date[] {
   );
 }
 
+export function millisecondsUntilNextLocalMidnight(now: Date): number {
+  const nextMidnight = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() + 1,
+  );
+  return nextMidnight.getTime() - now.getTime();
+}
+
 export function isToday(day: Date) {
   const today = new Date();
   return day.toDateString() === today.toDateString();


### PR DESCRIPTION
The planning grid derived the week and the today highlight from the
current date at render time, but nothing re-rendered at midnight, so a
window left open overnight kept highlighting the previous day.
Schedule a re-render at the next local midnight.