### PR TITLE
Add open-project-in-daylite change proposal

### DIFF
--- a/openspec/changes/open-project-in-daylite/.openspec.yaml
+++ b/openspec/changes/open-project-in-daylite/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/open-project-in-daylite/README.md
+++ b/openspec/changes/open-project-in-daylite/README.md
@@ -1,0 +1,3 @@
+# open-project-in-daylite
+
+Card action that opens the linked Daylite project in the Daylite macOS app

--- a/openspec/changes/open-project-in-daylite/README.md
+++ b/openspec/changes/open-project-in-daylite/README.md
@@ -1,3 +1,0 @@
-# open-project-in-daylite
-
-Card action that opens the linked Daylite project in the Daylite macOS app

--- a/openspec/changes/open-project-in-daylite/design.md
+++ b/openspec/changes/open-project-in-daylite/design.md
@@ -14,11 +14,13 @@ A second control cannot be nested inside it.
 
 `tauri-plugin-opener` is already a dependency but only reachable from Rust.
 The npm package `@tauri-apps/plugin-opener` is not installed, and the plugin's injected click handler hard-codes the schemes it intercepts to `http:`, `https:`, `mailto:` and `tel:`.
-A plain `<a href="daylite4://...">` is therefore not intercepted at all, and the webview drops the navigation.
+A plain `<a href="daylite://...">` is therefore not intercepted at all, and the webview drops the navigation.
 
-Daylite documents exactly one deep link.
-Marketcircle's interactive reports documentation gives `daylite4://ShowObject/<Entity>/<ObjectID>`, with `Project` as the entity name for projects, and states that it opens the object in Daylite.
-There is no documented parameter for anything else, tab handling included.
+Daylite's published documentation is out of date on the deep link.
+Marketcircle's interactive reports documentation gives `daylite4://ShowObject/<Entity>/<ObjectID>`.
+That form no longer works.
+The form a current Daylite accepts, confirmed by hand against the installed app, is `daylite://Command=ShowObject&Entity=Project&ID=<id>`.
+No parameter for anything else is known, tab handling included.
 
 ## Goals / Non-Goals
 
@@ -38,6 +40,16 @@ There is no documented parameter for anything else, tab handling included.
 
 ## Decisions
 
+### The URL form comes from testing, not from the documentation
+
+`daylite://Command=ShowObject&Entity=Project&ID=<id>` was arrived at by trying it against the installed Daylite.
+The `Entity` and `Command` names carry over from the documented `daylite4://` form, and the id is the numeric segment of the `/v1/projects/<id>` reference.
+
+Two things about this string invite a well-meant correction that would break it.
+It is not a query string: the parameters sit in the authority position, with no `?` after `daylite://`.
+And the scheme is `daylite:`, not the `daylite4:` that Marketcircle's own documentation still shows.
+Both are load-bearing, which is why the command builds the URL by formatting a string rather than through a URL type that would normalize it.
+
 ### A Rust command, not the opener plugin's own IPC command
 
 `daylite_open_project(project_ref: String)` takes the reference, extracts the numeric id, builds the URL, and calls `app.opener().open_url(url, None::<&str>)`.
@@ -48,7 +60,7 @@ This follows ADR 0001 and ADR 0009, and it makes the reference-to-URL translatio
 It also sidesteps the plugin's scope system, which is worth stating explicitly because the alternative looks cheaper than it is.
 The URL scope is enforced inside the plugin's own `open_url` IPC command, not inside `OpenerExt::open_url`.
 Calling the extension trait from our command is not scope-checked, so `src-tauri/capabilities/default.json` needs no entry.
-Going through the JS package instead would have required adding the npm dependency and widening the capability with an `opener:allow-open-url` scope entry for `daylite4:`, because `opener:default` expands to `allow-default-urls`, which covers only `mailto:`, `tel:`, `https://` and `http://`.
+Going through the JS package instead would have required adding the npm dependency and widening the capability with an `opener:allow-open-url` scope entry for `daylite:`, because `opener:default` expands to `allow-default-urls`, which covers only `mailto:`, `tel:`, `https://` and `http://`.
 
 Alternative considered and rejected: returning the URL from Rust and opening it in the frontend.
 It splits one operation across the boundary for no gain and still needs the scope entry.
@@ -87,14 +99,13 @@ The deep link is derived when the button is pressed.
 
 ## Risks / Trade-offs
 
-The numeric id in the REST reference may not be the internal `projectID` the URL scheme expects.
-The evidence is circumstantial: Hookmark's published Daylite links use ids of the same shape as the ids in this project's own recorded API responses.
-If they differ, there is no exposed mapping between them and this change cannot be built as designed.
-→ Verify by hand against a real Daylite before writing any code.
-This is the first task, and a failure there stops the change rather than reshaping it.
+The URL form rests on a manual test rather than on documentation, so a future Daylite release could change it with nothing to warn us.
+The documented form has already gone stale once, which is how this one was found.
+→ Keep the URL in one Rust function so a later correction is a one-line change, and keep the format asserted in a unit test so the expected string is written down somewhere a reader will find it.
 
-`daylite4://` is documented against an older Daylite generation and its continued support is not stated anywhere current.
-→ Covered by the same manual check, which exercises the scheme end to end.
+The numeric id in the REST reference is taken to be the internal id the URL scheme expects.
+The shapes match and the link resolves, but the test that established the format may have used an id read out of Daylite rather than out of the API.
+→ Confirm once that an id taken from a `/v1/projects/<id>` reference opens that same project, before building on it.
 
 `open_url` launches detached, so a URL that no application handles produces no error the app can catch.
 → Accepted by decision.

--- a/openspec/changes/open-project-in-daylite/design.md
+++ b/openspec/changes/open-project-in-daylite/design.md
@@ -1,0 +1,115 @@
+## Context
+
+See proposal.md - Why.
+
+Four properties of the current code shape this design.
+
+The card already holds the reference.
+`CalendarCellEvent.projectRef` reaches the frontend as `/v1/projects/<id>`, written into the VEVENT `DESCRIPTION` by `build_ical_payload` and read back by `classify_event`.
+`CellEvent.projectStatus` is set only when the project was resolved against Daylite, which is what `isUnresolvedAssignment` in `src/app/types.ts` tests.
+
+The assignment card is itself a `<button>`.
+`DraggableAssignmentCard` renders one button carrying both the click that opens the edit modal and the dnd-kit drag listeners.
+A second control cannot be nested inside it.
+
+`tauri-plugin-opener` is already a dependency but only reachable from Rust.
+The npm package `@tauri-apps/plugin-opener` is not installed, and the plugin's injected click handler hard-codes the schemes it intercepts to `http:`, `https:`, `mailto:` and `tel:`.
+A plain `<a href="daylite4://...">` is therefore not intercepted at all, and the webview drops the navigation.
+
+Daylite documents exactly one deep link.
+Marketcircle's interactive reports documentation gives `daylite4://ShowObject/<Entity>/<ObjectID>`, with `Project` as the entity name for projects, and states that it opens the object in Daylite.
+There is no documented parameter for anything else, tab handling included.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The URL format lives in one place in Rust, so a future Daylite scheme change or a second entity type is a change to one function.
+- The action is added without changing how the card is clicked or dragged, so no existing grid behavior has to be re-tested for regressions.
+- The action area is a container from the start, so the second card action is a sibling rather than a re-layout.
+
+**Non-Goals:**
+
+- Detecting whether Daylite is installed.
+- Deep links to anything other than a project.
+- Reaching Daylite from the assignment modal, from a bare event, or from anywhere outside the grid card.
+- Influencing whether Daylite reuses a tab.
+  It is not exposed by the URL scheme, so it is Daylite's preference to make, not ours.
+
+## Decisions
+
+### A Rust command, not the opener plugin's own IPC command
+
+`daylite_open_project(project_ref: String)` takes the reference, extracts the numeric id, builds the URL, and calls `app.opener().open_url(url, None::<&str>)`.
+The frontend calls it through the generated bindings and never sees a URL.
+
+This follows ADR 0001 and ADR 0009, and it makes the reference-to-URL translation a plain Rust unit test with no Tauri runtime and no HTTP cassette.
+
+It also sidesteps the plugin's scope system, which is worth stating explicitly because the alternative looks cheaper than it is.
+The URL scope is enforced inside the plugin's own `open_url` IPC command, not inside `OpenerExt::open_url`.
+Calling the extension trait from our command is not scope-checked, so `src-tauri/capabilities/default.json` needs no entry.
+Going through the JS package instead would have required adding the npm dependency and widening the capability with an `opener:allow-open-url` scope entry for `daylite4:`, because `opener:default` expands to `allow-default-urls`, which covers only `mailto:`, `tel:`, `https://` and `http://`.
+
+Alternative considered and rejected: returning the URL from Rust and opening it in the frontend.
+It splits one operation across the boundary for no gain and still needs the scope entry.
+
+### An overlaid action area, not a restructured card
+
+The action area is a sibling of the card button inside the existing `<li>`, positioned over the card's right edge, and the card button gains right padding so its title stops before the area begins.
+
+Nesting is not available: a `<button>` inside a `<button>` is invalid, and the card button is where both the modal click and the drag listeners sit.
+Being a sibling rather than a descendant also means dnd-kit never sees the pointer events on the action, so no `stopPropagation` guard is needed to keep a press on the action from starting a drag.
+
+Alternative considered and rejected: splitting the card into a flex row whose label is the button and whose actions are siblings in normal flow.
+That moves the drag handle and the click target onto a smaller element, which changes drag behavior across the whole grid to add one button.
+
+The card's `lifted` state hides the card button while a drag is in flight, and the action area has to be hidden by the same flag.
+Otherwise it would be left visible in an `<li>` collapsed to zero height, floating over the row below.
+
+### Gate on the resolved project, not on the reference alone
+
+The action is rendered when `event.kind === "assignment"` and `isUnresolvedAssignment(event)` is false, which is the same predicate the grid already uses to decide whether a card is draggable.
+
+The deep link would technically work for an unresolved assignment, since it needs only the id and not the Daylite API.
+Showing it anyway was considered and rejected: an unresolved card already tells the planner that this reference could not be read, and offering a jump from a card in that state invites the reading that the app knows more about the project than it is showing.
+
+### `ExternalLink` from Lucide
+
+The codebase already uses `ExternalLink` for the one control that leaves the app, the token link in `daylite-panel.tsx`, so the icon keeps its established meaning of "this opens somewhere else".
+`Link` reads as a chain and is the more literal icon for a link, but it is used in most icon sets for creating or holding a link rather than following one.
+Swapping it is a one-line change if the second card action makes a different pairing look better.
+
+### The deep link is never persisted
+
+The VEVENT `DESCRIPTION` keeps `daylite:/v1/projects/<id>`.
+It is load-bearing for `classify_event`, which reads the first description line to tell an assignment from a bare event, and it is what every write path reproduces.
+The deep link is derived when the button is pressed.
+
+## Risks / Trade-offs
+
+The numeric id in the REST reference may not be the internal `projectID` the URL scheme expects.
+The evidence is circumstantial: Hookmark's published Daylite links use ids of the same shape as the ids in this project's own recorded API responses.
+If they differ, there is no exposed mapping between them and this change cannot be built as designed.
+→ Verify by hand against a real Daylite before writing any code.
+This is the first task, and a failure there stops the change rather than reshaping it.
+
+`daylite4://` is documented against an older Daylite generation and its continued support is not stated anywhere current.
+→ Covered by the same manual check, which exercises the scheme end to end.
+
+`open_url` launches detached, so a URL that no application handles produces no error the app can catch.
+→ Accepted by decision.
+macOS shows its own dialog, and building an install check to replace it is explicitly out of scope.
+
+The action overlays the card rather than sharing its flow, so a very narrow column could put the icon over wrapped title text.
+→ The card button's right padding reserves the width, and a title that no longer fits wraps instead of running under the icon.
+Worth a look at the narrowest column the grid produces.
+
+## Migration Plan
+
+None.
+The change is additive: no stored data, no calendar payload, and no existing command contract changes, so it needs no migration and is reverted by removing the command and the button.
+
+## Open Questions
+
+Whether the two card actions, once the second one exists, still read clearly as icons alone or want a tooltip.
+It changes neither the specs nor the task breakdown and is better answered with both buttons on screen.

--- a/openspec/changes/open-project-in-daylite/design.md
+++ b/openspec/changes/open-project-in-daylite/design.md
@@ -20,6 +20,7 @@ Daylite's published documentation is out of date on the deep link.
 Marketcircle's interactive reports documentation gives `daylite4://ShowObject/<Entity>/<ObjectID>`.
 That form no longer works.
 The form a current Daylite accepts, confirmed by hand against the installed app, is `daylite://Command=ShowObject&Entity=Project&ID=<id>`.
+The id in it is the numeric segment of the `/v1/projects/<id>` API reference, so the card carries the identifier the link wants without a lookup.
 No parameter for anything else is known, tab handling included.
 
 ## Goals / Non-Goals
@@ -42,8 +43,7 @@ No parameter for anything else is known, tab handling included.
 
 ### The URL form comes from testing, not from the documentation
 
-`daylite://Command=ShowObject&Entity=Project&ID=<id>` was arrived at by trying it against the installed Daylite.
-The `Entity` and `Command` names carry over from the documented `daylite4://` form, and the id is the numeric segment of the `/v1/projects/<id>` reference.
+`daylite://Command=ShowObject&Entity=Project&ID=<id>` was arrived at by trying it against the installed Daylite, with an id taken from a `/v1/projects/<id>` reference.
 
 Two things about this string invite a well-meant correction that would break it.
 It is not a query string: the parameters sit in the authority position, with no `?` after `daylite://`.
@@ -102,10 +102,6 @@ The deep link is derived when the button is pressed.
 The URL form rests on a manual test rather than on documentation, so a future Daylite release could change it with nothing to warn us.
 The documented form has already gone stale once, which is how this one was found.
 → Keep the URL in one Rust function so a later correction is a one-line change, and keep the format asserted in a unit test so the expected string is written down somewhere a reader will find it.
-
-The numeric id in the REST reference is taken to be the internal id the URL scheme expects.
-The shapes match and the link resolves, but the test that established the format may have used an id read out of Daylite rather than out of the API.
-→ Confirm once that an id taken from a `/v1/projects/<id>` reference opens that same project, before building on it.
 
 `open_url` launches detached, so a URL that no application handles produces no error the app can catch.
 → Accepted by decision.

--- a/openspec/changes/open-project-in-daylite/design.md
+++ b/openspec/changes/open-project-in-daylite/design.md
@@ -8,9 +8,13 @@ The card already holds the reference.
 `CalendarCellEvent.projectRef` reaches the frontend as `/v1/projects/<id>`, written into the VEVENT `DESCRIPTION` by `build_ical_payload` and read back by `classify_event`.
 `CellEvent.projectStatus` is set only when the project was resolved against Daylite, which is what `isUnresolvedAssignment` in `src/app/types.ts` tests.
 
-The assignment card is itself a `<button>`.
-`DraggableAssignmentCard` renders one button carrying both the click that opens the edit modal and the dnd-kit drag listeners.
-A second control cannot be nested inside it.
+The assignment card is one button carrying two jobs.
+`DraggableAssignmentCard` renders a single `<button>` holding both the click that opens the edit modal and the dnd-kit drag listeners.
+Nothing can be placed inside it that is itself pressable, which is what this change unpicks.
+
+Keyboard dragging is not wired up.
+`page.tsx` registers only `PointerSensor`, so the `role="button"` and `tabIndex` that dnd-kit's `attributes` put on the card today buy no keyboard drag.
+Dropping them costs nothing that works.
 
 `tauri-plugin-opener` is already a dependency but only reachable from Rust.
 The npm package `@tauri-apps/plugin-opener` is not installed, and the plugin's injected click handler hard-codes the schemes it intercepts to `http:`, `https:`, `mailto:` and `tel:`.
@@ -28,13 +32,15 @@ No parameter for anything else is known, tab handling included.
 **Goals:**
 
 - The URL format lives in one place in Rust, so a future Daylite scheme change or a second entity type is a change to one function.
-- The action is added without changing how the card is clicked or dragged, so no existing grid behavior has to be re-tested for regressions.
-- The action area is a container from the start, so the second card action is a sibling rather than a re-layout.
+- The card's actions are siblings in the card's normal flow, so a third action is an added element rather than a re-layout.
+- Dragging keeps feeling the same to a planner, and pressing an action can never be mistaken for the start of one.
 
 **Non-Goals:**
 
 - Detecting whether Daylite is installed.
 - Deep links to anything other than a project.
+- Making the card keyboard-draggable.
+  It is not today, and this change neither adds nor removes that.
 - Reaching Daylite from the assignment modal, from a bare event, or from anywhere outside the grid card.
 - Influencing whether Daylite reuses a tab.
   It is not exposed by the URL scheme, so it is Daylite's preference to make, not ours.
@@ -65,39 +71,62 @@ Going through the JS package instead would have required adding the npm dependen
 Alternative considered and rejected: returning the URL from Rust and opening it in the frontend.
 It splits one operation across the boundary for no gain and still needs the scope entry.
 
-### An overlaid action area, not a restructured card
+### The card stops being a control, and its actions sit in its normal flow
 
-The action area is a sibling of the card button inside the existing `<li>`, positioned over the card's right edge, and the card button gains right padding so its title stops before the area begins.
+The card becomes a container laying out three things in a row: the times and title as before, then the edit action, then the Daylite action.
+Neither action is nested in anything pressable, so both are ordinary buttons and no propagation guard is needed to keep one from triggering the other.
 
-Nesting is not available: a `<button>` inside a `<button>` is invalid, and the card button is where both the modal click and the drag listeners sit.
-Being a sibling rather than a descendant also means dnd-kit never sees the pointer events on the action, so no `stopPropagation` guard is needed to keep a press on the action from starting a drag.
+Making the card a container rather than a button is what buys this.
+While it was a button, the only way to add a second control was to overlay it as a sibling positioned over the card's right edge, with reserved padding on the card so the title did not run underneath, because a `<button>` cannot contain a `<button>`.
+That arrangement worked for one action and got worse with each one added.
+In normal flow the row measures itself, the title's `flex-1 min-w-0` shrinks around whatever the actions need, and the narrow-column overlap it would otherwise have risked cannot happen.
 
-Alternative considered and rejected: splitting the card into a flex row whose label is the button and whose actions are siblings in normal flow.
-That moves the drag handle and the click target onto a smaller element, which changes drag behavior across the whole grid to add one button.
+The cost is that the card no longer announces itself as pressable, and a planner used to clicking anywhere on a card has to find the pencil.
+That is the change being asked for, and it is what makes the two actions distinguishable at all.
 
-The card's `lifted` state hides the card button while a drag is in flight, and the action area has to be hidden by the same flag.
-Otherwise it would be left visible in an `<li>` collapsed to zero height, floating over the row below.
+### `setNodeRef` on the card, `setActivatorNodeRef` on the body
 
-### Gate on the resolved project, not on the reference alone
+dnd-kit separates the element it measures from the element that starts a drag.
+`setNodeRef` goes on the card container, so the rect the drop logic and the overlay use still covers the whole card as it does today.
+`setActivatorNodeRef` and the drag `listeners` go on the body, the times-and-title region, so a press on either action is not a press on the drag activator.
 
-The action is rendered when `event.kind === "assignment"` and `isUnresolvedAssignment(event)` is false, which is the same predicate the grid already uses to decide whether a card is draggable.
+This is what keeps "pressing an action never starts a drag" true without a `stopPropagation` handler on each action, and it keeps the draggable area the part of the card a planner would grab anyway.
 
+dnd-kit's `attributes` are not spread as they are today.
+They carry `role="button"` and `tabIndex`, which on a card that is no longer a control would announce a control that does nothing.
+`aria-roledescription` is kept so the card still describes itself as draggable.
+Nothing is lost, because no `KeyboardSensor` is registered.
+
+Alternative considered and rejected: leaving the listeners on the container and calling `stopPropagation` on each action's pointer-down.
+It puts a guard on every action forever, and forgetting it on the third one is a bug that only shows up as an accidental drag.
+
+### The edit action is shown on every assignment, the Daylite action is not
+
+The edit action does not depend on Daylite being reachable, and withholding it would make an assignment whose project could not be read impossible to correct or delete.
+So it is shown whenever the card is an assignment.
+
+The Daylite action is shown only when `isUnresolvedAssignment(event)` is false.
 The deep link would technically work for an unresolved assignment, since it needs only the id and not the Daylite API.
 Showing it anyway was considered and rejected: an unresolved card already tells the planner that this reference could not be read, and offering a jump from a card in that state invites the reading that the app knows more about the project than it is showing.
 
-### `ExternalLink` from Lucide
+### Icons and their order
 
-The codebase already uses `ExternalLink` for the one control that leaves the app, the token link in `daylite-panel.tsx`, so the icon keeps its established meaning of "this opens somewhere else".
-`Link` reads as a chain and is the more literal icon for a link, but it is used in most icon sets for creating or holding a link rather than following one.
-Swapping it is a one-line change if the second card action makes a different pairing look better.
+Edit is Lucide `Pencil`, the Daylite jump is Lucide `ExternalLink`.
+`ExternalLink` already carries the meaning "this opens somewhere else" in this codebase, on the token link in `daylite-panel.tsx`.
+`Link` reads as a chain and is the more literal icon for a link, but in most icon sets it means making or holding a link rather than following one.
 
-### The deep link is never persisted
-
-The VEVENT `DESCRIPTION` keeps `daylite:/v1/projects/<id>`.
-It is load-bearing for `classify_event`, which reads the first description line to tell an assignment from a bare event, and it is what every write path reproduces.
-The deep link is derived when the button is pressed.
+Edit comes first because it is the action a planner reaches for most, and it is the one every assignment card has.
+Fixing the order at all is the point: a Daylite action that moves depending on whether it is present would put the pencil in a different place on neighbouring cards.
 
 ## Risks / Trade-offs
+
+The card loses its click target, which is a habit change for every planner using the app today.
+→ Nothing in the design softens it, by choice.
+Worth watching after the first release rather than pre-empting with a transitional affordance.
+
+The two icons sit on a card that can be narrow, and they are small pointer targets compared to the whole card.
+→ They share the card's full height in the flex row, so the target is taller than the icon.
+Check it against the narrowest column the grid produces.
 
 The URL form rests on a manual test rather than on documentation, so a future Daylite release could change it with nothing to warn us.
 The documented form has already gone stale once, which is how this one was found.
@@ -107,16 +136,13 @@ The documented form has already gone stale once, which is how this one was found
 → Accepted by decision.
 macOS shows its own dialog, and building an install check to replace it is explicitly out of scope.
 
-The action overlays the card rather than sharing its flow, so a very narrow column could put the icon over wrapped title text.
-→ The card button's right padding reserves the width, and a title that no longer fits wraps instead of running under the icon.
-Worth a look at the narrowest column the grid produces.
-
 ## Migration Plan
 
 None.
-The change is additive: no stored data, no calendar payload, and no existing command contract changes, so it needs no migration and is reverted by removing the command and the button.
+No stored data, no calendar payload, and no existing command contract changes.
+The Daylite half is reverted by removing the command and the action; the card restructuring is reverted by putting the click back on the card.
 
 ## Open Questions
 
-Whether the two card actions, once the second one exists, still read clearly as icons alone or want a tooltip.
-It changes neither the specs nor the task breakdown and is better answered with both buttons on screen.
+Whether the two actions read clearly as icons alone or want a tooltip.
+It changes neither the specs nor the task breakdown and is better answered with both on screen.

--- a/openspec/changes/open-project-in-daylite/proposal.md
+++ b/openspec/changes/open-project-in-daylite/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+A planner looking at an assignment card in the grid has the Daylite project reference right there, but reaching the project itself means switching to Daylite and searching for it by name.
+The card already carries everything needed to jump straight to the record, and Daylite for Mac accepts a documented deep link that does exactly that.
+
+## What Changes
+
+- Assignment cards in the planning grid gain an action button on their right edge that opens the card's Daylite project in the Daylite macOS app.
+- The button is icon-only, borderless and transparent, and sits in an action area on the card so a second card action can join it later without further layout work.
+- The button is shown only on assignment cards whose Daylite project reference resolved.
+  Bare events, absences, and assignments whose project could not be read carry no button.
+- A new Rust command builds the `daylite4://ShowObject/Project/<id>` URL from the card's project reference and hands it to the system, following ADR 0001: the frontend passes the reference and never constructs the URL.
+- Whether Daylite is installed is not checked.
+  An unregistered URL scheme is left to macOS, which reports it in its own dialog.
+- Pressing the action button neither opens the edit modal nor starts a drag.
+- The iCal `DESCRIPTION` stays `daylite:/v1/projects/<id>` as it is today.
+  The deep link is built when the button is pressed and is never written to the calendar.
+
+## Capabilities
+
+### New Capabilities
+
+- `daylite-deep-link`: opening a Daylite record in the Daylite macOS app from the planning grid, covering the URL contract, which cards offer the action, and how the action coexists with the card's click and drag behavior.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Backend: a new `daylite_open_project` command in `src-tauri/src/integrations/daylite/`, registered in `src-tauri/src/lib.rs`.
+- Frontend: `src/app/components/timetable-cell.tsx` (the card gains an action area), and a service wrapper alongside the existing Daylite services.
+- Generated Tauri bindings in `src/generated/tauri.ts` are regenerated.
+- No new Rust or npm dependency: `tauri-plugin-opener` is already a dependency and `lucide-react` already supplies the icon.
+- No capability scope change in `src-tauri/capabilities/default.json`.
+  The plugin enforces its URL scope inside its own IPC command, which this change does not use.
+- macOS only in effect.
+  On other platforms the button is still rendered and the URL still opened, and the platform decides what happens.

--- a/openspec/changes/open-project-in-daylite/proposal.md
+++ b/openspec/changes/open-project-in-daylite/proposal.md
@@ -1,38 +1,48 @@
 ## Why
 
 A planner looking at an assignment card in the grid has the Daylite project reference right there, but reaching the project itself means switching to Daylite and searching for it by name.
-The card already carries everything needed to jump straight to the record, and Daylite for Mac accepts a documented deep link that does exactly that.
+The card already carries everything needed to jump straight to the record, and Daylite for Mac accepts a deep link that does exactly that.
+
+Adding that jump to a card that is itself one big button leaves nowhere to put it.
+So the card gives up being a control, and both the jump and the edit it already had become named actions on its right edge.
 
 ## What Changes
 
-- Assignment cards in the planning grid gain an action button on their right edge that opens the card's Daylite project in the Daylite macOS app.
-- The button is icon-only, borderless and transparent, and sits in an action area on the card so a second card action can join it later without further layout work.
-- The button is shown only on assignment cards whose Daylite project reference resolved.
-  Bare events, absences, and assignments whose project could not be read carry no button.
+- The assignment card stops being a button.
+  Clicking its body no longer opens the edit modal and no longer does anything at all.
+- Assignment cards gain an action area on their right edge holding icon-only, borderless, transparent controls.
+- Editing moves into that area as the first action.
+  It is shown on every assignment card, including one whose Daylite project could not be resolved, so an assignment stays editable and deletable whether or not Daylite can be reached.
+- A second action in that area opens the card's Daylite project in the Daylite macOS app.
+  It is shown only where the Daylite project reference resolved.
+- Dragging a card is unchanged for the planner, but is activated from the card's body rather than from the whole card, so pressing an action never starts a drag.
 - A new Rust command builds the `daylite://Command=ShowObject&Entity=Project&ID=<id>` URL from the card's project reference and hands it to the system, following ADR 0001: the frontend passes the reference and never constructs the URL.
 - Whether Daylite is installed is not checked.
   An unregistered URL scheme is left to macOS, which reports it in its own dialog.
-- Pressing the action button neither opens the edit modal nor starts a drag.
 - The iCal `DESCRIPTION` stays `daylite:/v1/projects/<id>` as it is today.
-  The deep link is built when the button is pressed and is never written to the calendar.
+  The deep link is built when the action is triggered and is never written to the calendar.
 
 ## Capabilities
 
 ### New Capabilities
 
-- `daylite-deep-link`: opening a Daylite record in the Daylite macOS app from the planning grid, covering the URL contract, which cards offer the action, and how the action coexists with the card's click and drag behavior.
+- `daylite-deep-link`: opening a Daylite record in the Daylite macOS app from the planning grid, covering the URL contract, which cards offer the action, how it looks and where it sits, and its isolation from the card's other behavior.
 
 ### Modified Capabilities
 
-None.
+- `assignment-persistence`: an assignment card is no longer a control, its actions sit in an action area on its right edge, and the edit affordance is one of them and is present even on an unresolved assignment.
+- `assignment-modal-crud`: edit mode is opened from an assignment card's edit action rather than by clicking the card.
+- `appointment-drag-drop`: a drag is activated from the card's body, and a press on a card action never starts one.
 
 ## Impact
 
 - Backend: a new `daylite_open_project` command in `src-tauri/src/integrations/daylite/`, registered in `src-tauri/src/lib.rs`.
-- Frontend: `src/app/components/timetable-cell.tsx` (the card gains an action area), and a service wrapper alongside the existing Daylite services.
+- Frontend: `src/app/components/timetable-cell.tsx` carries the whole card restructuring, and a service wrapper joins the existing Daylite services.
+  `src/app/components/timetable-row.tsx` keeps passing the edit callback, now reached from the action rather than the card.
 - Generated Tauri bindings in `src/generated/tauri.ts` are regenerated.
-- No new Rust or npm dependency: `tauri-plugin-opener` is already a dependency and `lucide-react` already supplies the icon.
+- Existing tests that open the modal by clicking an assignment card need updating, in `timetable-cell.spec.tsx` and in the grid-level specs that exercise the edit flow.
+- No new Rust or npm dependency: `tauri-plugin-opener` is already a dependency and `lucide-react` already supplies both icons.
 - No capability scope change in `src-tauri/capabilities/default.json`.
   The plugin enforces its URL scope inside its own IPC command, which this change does not use.
-- macOS only in effect.
-  On other platforms the button is still rendered and the URL still opened, and the platform decides what happens.
+- macOS only in effect for the Daylite action.
+  On other platforms it is still rendered and the URL still opened, and the platform decides what happens.

--- a/openspec/changes/open-project-in-daylite/proposal.md
+++ b/openspec/changes/open-project-in-daylite/proposal.md
@@ -9,7 +9,7 @@ The card already carries everything needed to jump straight to the record, and D
 - The button is icon-only, borderless and transparent, and sits in an action area on the card so a second card action can join it later without further layout work.
 - The button is shown only on assignment cards whose Daylite project reference resolved.
   Bare events, absences, and assignments whose project could not be read carry no button.
-- A new Rust command builds the `daylite4://ShowObject/Project/<id>` URL from the card's project reference and hands it to the system, following ADR 0001: the frontend passes the reference and never constructs the URL.
+- A new Rust command builds the `daylite://Command=ShowObject&Entity=Project&ID=<id>` URL from the card's project reference and hands it to the system, following ADR 0001: the frontend passes the reference and never constructs the URL.
 - Whether Daylite is installed is not checked.
   An unregistered URL scheme is left to macOS, which reports it in its own dialog.
 - Pressing the action button neither opens the edit modal nor starts a drag.

--- a/openspec/changes/open-project-in-daylite/specs/appointment-drag-drop/spec.md
+++ b/openspec/changes/open-project-in-daylite/specs/appointment-drag-drop/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Draggable assignment cards
+The system SHALL allow assignment cards (`kind: "assignment"`) in the planning grid to be picked up and dragged by their body, leaving the card's action controls free to be pressed.
+
+#### Scenario: Assignment card is draggable
+- **WHEN** the user presses and drags an assignment card's body past the activation threshold
+- **THEN** a drag operation starts carrying that assignment's identity (UID, href, source employee, source date)
+- **AND** the source card is visually marked as being dragged
+
+#### Scenario: Bare and absence events are not draggable
+- **WHEN** the user attempts to drag a bare or absence event card
+- **THEN** no drag operation starts
+- **AND** the card remains in place
+
+#### Scenario: Assignments with an unresolved project are not draggable
+- **WHEN** an assignment's Daylite project could not be resolved and its card shows the German placeholder text
+- **THEN** the card is not draggable until the project data is available
+- **AND** its edit action still opens the edit modal
+
+#### Scenario: Click still opens the edit modal
+- **WHEN** the user presses an assignment card's body without moving past the activation threshold
+- **THEN** nothing happens, because the card body is no longer a control
+- **AND** the edit modal is reached through the card's edit action instead
+
+#### Scenario: Pressing a card action never starts a drag
+- **WHEN** the user presses and moves the pointer on one of the card's action controls
+- **THEN** no drag operation starts and the card stays in place

--- a/openspec/changes/open-project-in-daylite/specs/assignment-modal-crud/spec.md
+++ b/openspec/changes/open-project-in-daylite/specs/assignment-modal-crud/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Open modal from cell interaction
+The system SHALL open the assignment modal in create mode when the user clicks the add affordance of an employee/day cell, and in edit mode when the user triggers an assignment card's edit action.
+
+#### Scenario: Click empty cell opens create mode
+- **WHEN** user clicks the add affordance on an employee/day cell without assignment
+- **THEN** modal opens in create mode
+- **AND** employee and day are pre-selected
+
+#### Scenario: Click assigned cell opens edit mode
+- **WHEN** the user triggers the edit action on an assignment card in an employee/day cell
+- **THEN** modal opens in edit mode for that assignment
+- **AND** current assignment is pre-populated
+
+#### Scenario: Clicking an assignment card opens nothing
+- **WHEN** the user clicks an assignment card anywhere other than its action controls
+- **THEN** no modal opens
+- **AND** the modal is reached through the card's edit action instead

--- a/openspec/changes/open-project-in-daylite/specs/assignment-persistence/spec.md
+++ b/openspec/changes/open-project-in-daylite/specs/assignment-persistence/spec.md
@@ -1,0 +1,63 @@
+## MODIFIED Requirements
+
+### Requirement: Two-tier event display
+The system SHALL distinguish lkr-planner assignments from bare calendar events.
+
+#### Scenario: Display lkr-planner assignment
+- **WHEN** a VEVENT has a DESCRIPTION first line matching `daylite:/<path>`
+- **THEN** it is shown on a neutral card carrying a strip in its Daylite project's category color (`hex_colour`)
+- **AND** an edit affordance is shown in the card's action area
+
+#### Scenario: Assignment cards carry an action area
+- **WHEN** an assignment card is rendered
+- **THEN** its actions sit together on the right edge of the card as icon-only controls
+- **AND** the card itself is not a control: the only things on it that can be triggered are the actions in that area
+
+#### Scenario: The edit affordance is always available on an assignment
+- **WHEN** an assignment card is rendered, including one whose Daylite project could not be resolved
+- **THEN** the edit action is shown
+- **AND** an assignment stays editable and deletable regardless of whether Daylite could be reached
+
+#### Scenario: Category color is applied verbatim
+- **WHEN** an assignment event is rendered with a category color
+- **THEN** the value from Daylite is used as-is, so any CSS color notation it uses still applies
+- **AND** it colors only the strip, leaving the card surface and its text unchanged
+
+#### Scenario: Assignment without a category color
+- **WHEN** a resolved Daylite project has no category, or its category has no color
+- **THEN** the strip keeps its default muted color, the same one for every project status
+
+#### Scenario: Category color is joined where the card is rendered
+- **WHEN** an assignment card is rendered
+- **THEN** its strip color comes from looking the project's category up in the category color map
+- **AND** the map is read once for the whole session, so a recolored category appears after a reload or a restart
+
+#### Scenario: Bare events carry no strip
+- **WHEN** an event has no Daylite project reference
+- **THEN** it is rendered without a strip
+- **AND** it shares the same surface color as an assignment, so the strip alone marks an event as an assignment
+
+#### Scenario: Display bare event
+- **WHEN** a VEVENT has no structured Daylite project reference
+- **THEN** it is shown with neutral/grey styling
+- **AND** no action area and no edit affordance are shown (read-only)
+- **AND** covers legacy manually-created events and employee blockers
+
+#### Scenario: Display event start and end time
+- **WHEN** a VEVENT has a start time (non-all-day event)
+- **THEN** the start time is shown in HH:MM format on the left of the event card
+- **AND** the end time is shown below the start time if present
+- **AND** all-day events show no time
+
+#### Scenario: Event card hover feedback
+- **WHEN** the user hovers over any event card
+- **THEN** a visual hover indicator is shown
+
+#### Scenario: Card action hover feedback
+- **WHEN** the user hovers over one of an assignment card's actions
+- **THEN** that action is marked as the thing under the pointer, distinctly from the card's own hover indicator
+
+#### Scenario: Long event titles
+- **WHEN** an event title exceeds the card width
+- **THEN** the title wraps to multiple lines
+- **AND** the card grows vertically to accommodate the text

--- a/openspec/changes/open-project-in-daylite/specs/daylite-deep-link/spec.md
+++ b/openspec/changes/open-project-in-daylite/specs/daylite-deep-link/spec.md
@@ -24,7 +24,7 @@ The system SHALL address a Daylite project by the numeric identifier carried in 
 
 #### Scenario: Reference is translated to a deep link
 - **WHEN** a project reference of the form `/v1/projects/<id>` is opened
-- **THEN** the URL `daylite4://ShowObject/Project/<id>` is opened
+- **THEN** the URL `daylite://Command=ShowObject&Entity=Project&ID=<id>` is opened
 
 #### Scenario: Reference does not name a project
 - **WHEN** the reference does not have the form `/v1/projects/<id>` with a numeric id

--- a/openspec/changes/open-project-in-daylite/specs/daylite-deep-link/spec.md
+++ b/openspec/changes/open-project-in-daylite/specs/daylite-deep-link/spec.md
@@ -32,52 +32,48 @@ The system SHALL address a Daylite project by the numeric identifier carried in 
 - **AND** the failure is reported to the frontend as a German error message
 
 ### Requirement: Only cards with a resolved Daylite project offer the action
-The system SHALL show the action exclusively on assignment cards whose Daylite project reference was resolved against Daylite.
+The system SHALL show the Daylite action exclusively on assignment cards whose Daylite project reference was resolved against Daylite.
 
 #### Scenario: Resolved assignment
 - **WHEN** an assignment card carries a Daylite project reference and the project resolved
-- **THEN** the action is shown on the card
+- **THEN** the Daylite action is shown alongside the card's edit action
 
 #### Scenario: Unresolved assignment
 - **WHEN** an assignment card carries a Daylite project reference whose project could not be read, so the card shows the German placeholder note
-- **THEN** no action is shown on the card
+- **THEN** no Daylite action is shown
+- **AND** the card's edit action is still shown, so the assignment stays editable
 
 #### Scenario: Bare and absence events
 - **WHEN** a card is a bare calendar event or an absence
-- **THEN** no action is shown on the card
+- **THEN** no Daylite action is shown on the card
 
-### Requirement: Card action area
-The system SHALL place card actions in an area on the right edge of an assignment card, holding icon-only controls without a border or a background of their own.
+### Requirement: Appearance and placement of the Daylite action
+The system SHALL present the Daylite action as one of the icon-only controls in the assignment card's action area.
 
 #### Scenario: Appearance of the action
-- **WHEN** the action is shown on an assignment card
-- **THEN** it is an icon-only control on the right edge of the card
-- **AND** it carries no border and no background of its own
+- **WHEN** the Daylite action is shown on an assignment card
+- **THEN** it is an icon-only control carrying no border and no background of its own
 - **AND** it carries a German accessible name naming what it opens
 
+#### Scenario: Order within the action area
+- **WHEN** an assignment card shows both actions
+- **THEN** the edit action comes first and the Daylite action after it, in the same order on every card
+
 #### Scenario: Card title keeps its room
-- **WHEN** an assignment card shows the action area
-- **THEN** the card's title does not run underneath it
+- **WHEN** an assignment card shows its action area
+- **THEN** the card's title does not run underneath the actions
 - **AND** a title too long for the remaining width still wraps and grows the card vertically
 
-#### Scenario: Action area holds more than one action
-- **WHEN** a further card action is added later
-- **THEN** it takes its place in the same area alongside the existing one without the card being laid out differently
+### Requirement: The Daylite action is isolated from the card's other behavior
+The system SHALL keep triggering the Daylite action from causing anything else the card does.
 
-### Requirement: Card actions do not disturb card interaction
-The system SHALL keep the card's own click and drag behavior reachable and unchanged where the action is shown.
-
-#### Scenario: Triggering the action does not open the modal
-- **WHEN** the planner triggers a card action
+#### Scenario: Opening Daylite does not open the modal
+- **WHEN** the planner triggers the Daylite action
 - **THEN** the edit modal does not open
 
-#### Scenario: Triggering the action does not start a drag
-- **WHEN** the planner presses and moves the pointer on a card action
+#### Scenario: Opening Daylite does not start a drag
+- **WHEN** the planner presses and moves the pointer on the Daylite action
 - **THEN** no drag operation starts and the card stays in place
-
-#### Scenario: The rest of the card behaves as before
-- **WHEN** the planner clicks or drags the card outside the action area
-- **THEN** the edit modal opens, or the drag starts, exactly as it does today
 
 #### Scenario: Card being dragged
 - **WHEN** a card is the one currently being dragged and is lifted out of the cell's flow

--- a/openspec/changes/open-project-in-daylite/specs/daylite-deep-link/spec.md
+++ b/openspec/changes/open-project-in-daylite/specs/daylite-deep-link/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Open a card's Daylite project in Daylite
+The system SHALL offer an action on an assignment card in the planning grid that opens the card's Daylite project in the Daylite macOS app, bringing Daylite to the front and showing that project.
+
+#### Scenario: Project opens in Daylite
+- **WHEN** the planner triggers the action on an assignment card whose Daylite project resolved
+- **THEN** the card's Daylite project reference is handed to the backend
+- **AND** the system asks macOS to open the Daylite deep link for that project
+- **AND** Daylite is launched if it is not running, or brought to the front if it is
+
+#### Scenario: Daylite decides how the project is presented
+- **WHEN** Daylite receives the deep link
+- **THEN** how the project is shown, in a new tab or in the current one, is Daylite's behavior
+- **AND** the system does not attempt to influence it
+
+#### Scenario: Daylite is not installed
+- **WHEN** no application is registered for the Daylite URL scheme
+- **THEN** the system does not check for Daylite beforehand and does not show a message of its own
+- **AND** the operating system reports the missing handler
+
+### Requirement: Deep link URL contract
+The system SHALL address a Daylite project by the numeric identifier carried in its Daylite reference.
+
+#### Scenario: Reference is translated to a deep link
+- **WHEN** a project reference of the form `/v1/projects/<id>` is opened
+- **THEN** the URL `daylite4://ShowObject/Project/<id>` is opened
+
+#### Scenario: Reference does not name a project
+- **WHEN** the reference does not have the form `/v1/projects/<id>` with a numeric id
+- **THEN** no URL is opened
+- **AND** the failure is reported to the frontend as a German error message
+
+### Requirement: Only cards with a resolved Daylite project offer the action
+The system SHALL show the action exclusively on assignment cards whose Daylite project reference was resolved against Daylite.
+
+#### Scenario: Resolved assignment
+- **WHEN** an assignment card carries a Daylite project reference and the project resolved
+- **THEN** the action is shown on the card
+
+#### Scenario: Unresolved assignment
+- **WHEN** an assignment card carries a Daylite project reference whose project could not be read, so the card shows the German placeholder note
+- **THEN** no action is shown on the card
+
+#### Scenario: Bare and absence events
+- **WHEN** a card is a bare calendar event or an absence
+- **THEN** no action is shown on the card
+
+### Requirement: Card action area
+The system SHALL place card actions in an area on the right edge of an assignment card, holding icon-only controls without a border or a background of their own.
+
+#### Scenario: Appearance of the action
+- **WHEN** the action is shown on an assignment card
+- **THEN** it is an icon-only control on the right edge of the card
+- **AND** it carries no border and no background of its own
+- **AND** it carries a German accessible name naming what it opens
+
+#### Scenario: Card title keeps its room
+- **WHEN** an assignment card shows the action area
+- **THEN** the card's title does not run underneath it
+- **AND** a title too long for the remaining width still wraps and grows the card vertically
+
+#### Scenario: Action area holds more than one action
+- **WHEN** a further card action is added later
+- **THEN** it takes its place in the same area alongside the existing one without the card being laid out differently
+
+### Requirement: Card actions do not disturb card interaction
+The system SHALL keep the card's own click and drag behavior reachable and unchanged where the action is shown.
+
+#### Scenario: Triggering the action does not open the modal
+- **WHEN** the planner triggers a card action
+- **THEN** the edit modal does not open
+
+#### Scenario: Triggering the action does not start a drag
+- **WHEN** the planner presses and moves the pointer on a card action
+- **THEN** no drag operation starts and the card stays in place
+
+#### Scenario: The rest of the card behaves as before
+- **WHEN** the planner clicks or drags the card outside the action area
+- **THEN** the edit modal opens, or the drag starts, exactly as it does today
+
+#### Scenario: Card being dragged
+- **WHEN** a card is the one currently being dragged and is lifted out of the cell's flow
+- **THEN** its action area is not visible either

--- a/openspec/changes/open-project-in-daylite/tasks.md
+++ b/openspec/changes/open-project-in-daylite/tasks.md
@@ -1,0 +1,41 @@
+## 1. Verify the deep link against a real Daylite
+
+- [ ] 1.1 Pick a project visible in both the Daylite macOS app and the Daylite API, and note the numeric id from its `/v1/projects/<id>` reference
+- [ ] 1.2 Open `daylite4://ShowObject/Project/<id>` from the browser address bar or `open` in a terminal and confirm Daylite comes forward on that exact project
+- [ ] 1.3 Record the result in design.md; if the id does not address the project, stop here and reopen the design rather than continuing
+
+## 2. Deep Link Command (TDD)
+
+- [ ] 2.1 (red) Rust unit test: `/v1/projects/2035` translates to `daylite4://ShowObject/Project/2035`
+- [ ] 2.2 (red) Rust unit test: a reference that is not `/v1/projects/<numeric id>` yields a German error instead of a URL
+- [ ] 2.3 (green) Implement the reference-to-URL translation as a pure function in `src-tauri/src/integrations/daylite/`
+- [ ] 2.4 (green) Add the `daylite_open_project` command wrapping the translation and `app.opener().open_url(url, None::<&str>)`
+- [ ] 2.5 Register the command in `specta_builder` in `src-tauri/src/lib.rs` and regenerate `src/generated/tauri.ts`
+- [ ] 2.6 Confirm `src-tauri/capabilities/default.json` needs no change by opening a card's project from a dev build
+
+## 3. Frontend Service (TDD)
+
+- [ ] 3.1 (red) Service test: opening a project reference invokes the command with that reference
+- [ ] 3.2 (red) Service test: a backend error surfaces as a German message rather than throwing
+- [ ] 3.3 (green) Implement the service wrapper alongside the existing Daylite services
+
+## 4. Card Action Area (TDD)
+
+- [ ] 4.1 (red) Component test: an assignment card with a resolved project renders the action with its German accessible name
+- [ ] 4.2 (red) Component test: an unresolved assignment, a bare event, and an absence render no action
+- [ ] 4.3 (red) Component test: the action is not rendered on the card currently being dragged
+- [ ] 4.4 (green) Add the action area as a sibling of the card button inside the existing `<li>`, positioned over the card's right edge
+- [ ] 4.5 (green) Add right padding on the card button so the title stops before the action area
+- [ ] 4.6 (green) Wire the action to the service with the card's `projectRef`
+
+## 5. Interaction and Appearance
+
+- [ ] 5.1 In a dev build, confirm pressing the action opens Daylite and does not open the edit modal
+- [ ] 5.2 In a dev build, confirm pressing and moving on the action starts no drag, and that dragging the card elsewhere still works
+- [ ] 5.3 Check the narrowest column the grid produces: a long title wraps and does not run under the icon
+- [ ] 5.4 Confirm the action carries no border and no background, and matches the card's hover feedback
+
+## 6. Close Out
+
+- [ ] 6.1 Run `bun test` and `bun run lint`
+- [ ] 6.2 Run `bunx openspec validate open-project-in-daylite`

--- a/openspec/changes/open-project-in-daylite/tasks.md
+++ b/openspec/changes/open-project-in-daylite/tasks.md
@@ -1,12 +1,15 @@
-## 1. Verify the deep link against a real Daylite
+## 1. Confirm the id source
+
+The URL form is already confirmed against the installed Daylite.
+What is left is confirming that the id the app will pass, taken from the API reference, is the id the link wants.
 
 - [ ] 1.1 Pick a project visible in both the Daylite macOS app and the Daylite API, and note the numeric id from its `/v1/projects/<id>` reference
-- [ ] 1.2 Open `daylite4://ShowObject/Project/<id>` from the browser address bar or `open` in a terminal and confirm Daylite comes forward on that exact project
-- [ ] 1.3 Record the result in design.md; if the id does not address the project, stop here and reopen the design rather than continuing
+- [ ] 1.2 Open `daylite://Command=ShowObject&Entity=Project&ID=<id>` with that id and confirm Daylite comes forward on that same project
+- [ ] 1.3 If the id does not address the project, stop here and reopen the design rather than continuing
 
 ## 2. Deep Link Command (TDD)
 
-- [ ] 2.1 (red) Rust unit test: `/v1/projects/2035` translates to `daylite4://ShowObject/Project/2035`
+- [ ] 2.1 (red) Rust unit test: `/v1/projects/2035` translates to `daylite://Command=ShowObject&Entity=Project&ID=2035`
 - [ ] 2.2 (red) Rust unit test: a reference that is not `/v1/projects/<numeric id>` yields a German error instead of a URL
 - [ ] 2.3 (green) Implement the reference-to-URL translation as a pure function in `src-tauri/src/integrations/daylite/`
 - [ ] 2.4 (green) Add the `daylite_open_project` command wrapping the translation and `app.opener().open_url(url, None::<&str>)`

--- a/openspec/changes/open-project-in-daylite/tasks.md
+++ b/openspec/changes/open-project-in-daylite/tasks.md
@@ -11,7 +11,6 @@
 - [ ] 2.3 (green) Implement the reference-to-URL translation as a pure function in `src-tauri/src/integrations/daylite/`
 - [ ] 2.4 (green) Add the `daylite_open_project` command wrapping the translation and `app.opener().open_url(url, None::<&str>)`
 - [ ] 2.5 Register the command in `specta_builder` in `src-tauri/src/lib.rs` and regenerate `src/generated/tauri.ts`
-- [ ] 2.6 Confirm `src-tauri/capabilities/default.json` needs no change by opening a card's project from a dev build
 
 ## 3. Frontend Service (TDD)
 
@@ -19,23 +18,35 @@
 - [ ] 3.2 (red) Service test: a backend error surfaces as a German message rather than throwing
 - [ ] 3.3 (green) Implement the service wrapper alongside the existing Daylite services
 
-## 4. Card Action Area (TDD)
+## 4. Card Loses Its Click (TDD)
 
-- [ ] 4.1 (red) Component test: an assignment card with a resolved project renders the action with its German accessible name
-- [ ] 4.2 (red) Component test: an unresolved assignment, a bare event, and an absence render no action
-- [ ] 4.3 (red) Component test: the action is not rendered on the card currently being dragged
-- [ ] 4.4 (green) Add the action area as a sibling of the card button inside the existing `<li>`, positioned over the card's right edge
-- [ ] 4.5 (green) Add right padding on the card button so the title stops before the action area
-- [ ] 4.6 (green) Wire the action to the service with the card's `projectRef`
+- [ ] 4.1 (red) Component test: an assignment card renders no control of its own around its times and title
+- [ ] 4.2 (red) Component test: an assignment card renders an edit action with its German accessible name, including when the project is unresolved
+- [ ] 4.3 (green) Turn the card from a button into a container laying out body, edit action, and a slot for further actions
+- [ ] 4.4 (green) Move `onEventClick` from the card to the edit action
+- [ ] 4.5 (green) Move the drag `listeners` and `setActivatorNodeRef` to the card body, keep `setNodeRef` on the container, and stop spreading `attributes`
 
-## 5. Interaction and Appearance
+## 5. Daylite Action (TDD)
 
-- [ ] 5.1 In a dev build, confirm pressing the action opens Daylite and does not open the edit modal
-- [ ] 5.2 In a dev build, confirm pressing and moving on the action starts no drag, and that dragging the card elsewhere still works
-- [ ] 5.3 Check the narrowest column the grid produces: a long title wraps and does not run under the icon
-- [ ] 5.4 Confirm the action carries no border and no background, and matches the card's hover feedback
+- [ ] 5.1 (red) Component test: a resolved assignment renders the Daylite action after the edit action, with its German accessible name
+- [ ] 5.2 (red) Component test: an unresolved assignment, a bare event, and an absence render no Daylite action
+- [ ] 5.3 (red) Component test: neither action is rendered on the card currently being dragged
+- [ ] 5.4 (green) Add the Daylite action to the action area and wire it to the service with the card's `projectRef`
 
-## 6. Close Out
+## 6. Existing Tests and Callers
 
-- [ ] 6.1 Run `bun test` and `bun run lint`
-- [ ] 6.2 Run `bunx openspec validate open-project-in-daylite`
+- [ ] 6.1 Update `timetable-cell.spec.tsx` and any grid-level spec that opens the edit modal by clicking an assignment card
+- [ ] 6.2 Confirm `timetable-row.tsx` still supplies the edit callback and needs no signature change
+
+## 7. Interaction and Appearance
+
+- [ ] 7.1 In a dev build, confirm the edit action opens the modal and the Daylite action opens Daylite, neither triggering the other
+- [ ] 7.2 In a dev build, confirm pressing and moving on either action starts no drag, and that dragging the card by its body still reschedules and reassigns as before
+- [ ] 7.3 Confirm clicking the card body does nothing
+- [ ] 7.4 Check the narrowest column the grid produces: a long title wraps, the two icons stay on the right edge, and neither overlaps the title
+- [ ] 7.5 Confirm both actions carry no border and no background, and are distinguishable on hover from the card's own hover indicator
+
+## 8. Close Out
+
+- [ ] 8.1 Run `bun test` and `bun run lint`
+- [ ] 8.2 Run `bunx openspec validate open-project-in-daylite`

--- a/openspec/changes/open-project-in-daylite/tasks.md
+++ b/openspec/changes/open-project-in-daylite/tasks.md
@@ -1,11 +1,8 @@
-## 1. Confirm the id source
+## 1. Confirm the deep link against a real Daylite
 
-The URL form is already confirmed against the installed Daylite.
-What is left is confirming that the id the app will pass, taken from the API reference, is the id the link wants.
-
-- [ ] 1.1 Pick a project visible in both the Daylite macOS app and the Daylite API, and note the numeric id from its `/v1/projects/<id>` reference
-- [ ] 1.2 Open `daylite://Command=ShowObject&Entity=Project&ID=<id>` with that id and confirm Daylite comes forward on that same project
-- [ ] 1.3 If the id does not address the project, stop here and reopen the design rather than continuing
+- [x] 1.1 Pick a project visible in both the Daylite macOS app and the Daylite API, and note the numeric id from its `/v1/projects/<id>` reference
+- [x] 1.2 Open `daylite://Command=ShowObject&Entity=Project&ID=<id>` with that id and confirm Daylite comes forward on that same project
+- [x] 1.3 Record the confirmed URL form in design.md
 
 ## 2. Deep Link Command (TDD)
 


### PR DESCRIPTION
## Description

Planning artifacts only, no implementation.

The assignment card in the planning grid stops being a button.
Clicking its body no longer opens the edit modal and no longer does anything.
Editing and a new jump to Daylite become icon-only, borderless actions on the card's right edge.

The Daylite action opens the card's project in the Daylite macOS app.
It is shown only where the project reference resolved.
The edit action is shown on every assignment card, including unresolved ones, so an assignment stays editable and deletable whether or not Daylite can be reached.

New capability `daylite-deep-link`, and three modified: `assignment-persistence`, `assignment-modal-crud`, `appointment-drag-drop`.

### Notable decisions

Dropping the card's own click is what makes room for the actions.
While the card was a button, a second control could only be overlaid on it as a sibling with reserved padding underneath, because a button cannot contain a button.
As a container the card lays out body and actions in normal flow, the title shrinks around whatever the actions need, and a third action is an added element rather than a re-layout.

The drag is split across two dnd-kit refs.
`setNodeRef` stays on the card container so the measured rect and the drag overlay still cover the whole card, while `setActivatorNodeRef` and the listeners move to the body.
A press on an action is therefore not a press on the drag activator, which keeps "an action never starts a drag" true without a `stopPropagation` guard on every action forever.
dnd-kit's `attributes` are no longer spread: they carry `role="button"` and `tabIndex`, which would announce a control that does nothing, and no `KeyboardSensor` is registered so nothing working is lost.

The URL is `daylite://Command=ShowObject&Entity=Project&ID=<id>`, confirmed by hand against the installed Daylite with an id taken from a `/v1/projects/<id>` reference.
Marketcircle's published `daylite4://ShowObject/<Entity>/<ObjectID>` form no longer works, and design.md records that so nobody corrects it back.
Two details invite a well-meant fix that would break it: the parameters sit in the authority position with no `?`, and the scheme is `daylite:` rather than `daylite4:`.
The command formats a string rather than going through a URL type that would normalize it.

A new Rust command `daylite_open_project` calls `app.opener().open_url`, following ADR 0001.
This sidesteps the opener plugin's URL scope, which is enforced inside the plugin's own IPC command rather than in `OpenerExt::open_url`, so `capabilities/default.json` needs no entry.
Going through the JS package instead would have required both a new npm dependency and a scope entry, because `opener:default` covers only `mailto:`, `tel:`, `https://` and `http://`.
A plain anchor was ruled out for the same reason: the plugin's injected click handler hard-codes those four schemes, so `<a href="daylite://...">` is never intercepted.

Whether Daylite is installed is not checked, by decision.
An unregistered scheme is left to macOS.

### What to look out for

The card losing its click target is a habit change for every planner using the app today, and nothing in the design softens it.
That is deliberate rather than an oversight, but it is the part most worth a second opinion.

Icon order is fixed as edit first, Daylite second, so the pencil does not move between a resolved and an unresolved card.

The URL form rests on a manual test rather than documentation, and the documented form has already gone stale once.
The mitigation is one Rust function with the expected string asserted in a unit test.

Existing tests that open the modal by clicking a card need updating; that is task group 6.

The Daylite action is rendered on every platform and only macOS does anything useful with it.
A platform gate looked like YAGNI for a Mac-targeted app, so it is a stated consequence in the proposal rather than a requirement.

## Reviewer checklist

- [x] Confirm the card should lose its click entirely, rather than keeping it as a shortcut to edit
- [x] Read the three delta specs and confirm the modified requirements still say what you want for drag, for opening the modal, and for the two-tier card display
- [x] Confirm the edit action belongs on unresolved assignment cards while the Daylite action does not
- [x] Confirm the icon choices and their order: Lucide `Pencil` then `ExternalLink`
- [x] Run `bunx openspec validate open-project-in-daylite`