### PR TITLE
Add OpenSpec change for highlighting matching events

### DIFF
--- a/openspec/changes/highlight-matching-events/.openspec.yaml
+++ b/openspec/changes/highlight-matching-events/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/highlight-matching-events/design.md
+++ b/openspec/changes/highlight-matching-events/design.md
@@ -1,0 +1,125 @@
+## Context
+
+See proposal.md - Why.
+
+Four properties of the current grid shape this design.
+
+Nothing in a `CellEvent` identifies the same work across employees.
+`uid` is the UID of one employee's CalDAV event, so it is unique per card and matches nothing else in the grid.
+`projectRef` is the Daylite reference (`/v1/projects/42`) and recurs wherever the project is scheduled.
+`title` is the resolved Daylite project name for an assignment and the iCal `SUMMARY` for a bare event.
+
+The grid already carries transient state from the root to every card.
+`useAppointmentDrag` holds `dropPreview` and `activePayload` in `PlanningGridTable`, and `week-table.tsx` and `timetable-row.tsx` pass them down to `TimetableCell` untouched.
+`dropPreview` is rewritten on every pointer move during a drag, so the grid already re-renders wholesale at pointer frequency and a second root-level value costs nothing measurable next to it.
+
+Rows already know how to drop transient state when the week changes.
+`TimetableRow` compares the rendered week start against the one its ghost belongs to and clears the ghost when they differ, which works for arrow navigation and for the trackpad swipe alike because both change the week the grid renders.
+
+A cell's `<td>` already uses `ring-2 ring-inset ring-primary` for the drop target and `ring-2 ring-inset ring-error` for an absence conflict.
+Both sit on the cell, not the card, so a ring on a card is unclaimed.
+A ring is a box shadow and costs no reflow, which matters in WKWebView, where a reflow on re-slotted cards is what `week-table.tsx` already works around with a forced repaint.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One question answered well: where else in this week is the work on this card.
+- The highlight outlives the gesture that started it, because the planner acts on what it shows after they stop pointing at the card.
+- No new data.
+  Everything the match needs already reaches the frontend on `CalendarCellEvent`.
+- No persistence.
+  The highlight is a reading aid for the session, never written to CalDAV or the local store.
+
+**Non-Goals:**
+
+- Hover, dwell, or drag as triggers.
+  All three are transient, and the highlight is wanted while the planner works rather than while they point.
+- Highlighting day headers, the employee column, or the cell background.
+  Cards only.
+- Matching across weeks.
+  The highlight applies to the week on screen.
+- Absences.
+  Their colors already separate the types, and a second visual language over them would compete with the conflict ring.
+- Multiple simultaneous highlights.
+- A toolbar list of the week's projects to pick from.
+  Worth revisiting if picking from a card turns out to be the wrong starting point, but it is a second entry point for a feature that has none yet.
+
+## Decisions
+
+### Kind-scoped highlight key
+
+The match key is derived from the event kind and one field, and two events match when their keys are equal:
+
+| Kind | Key | Rationale |
+| --- | --- | --- |
+| `assignment` | the Daylite project reference | Stable across a rename in Daylite, and two projects that happen to share a name stay distinct. |
+| `bare` | the trimmed title | A bare event carries no Daylite reference; its `SUMMARY` is all it has. |
+| `absence` | none, never highlightable | Excluded by decision, see Non-Goals. |
+
+The kind is part of the key, so a bare event titled "Bauprojekt Nord" does not match assignments for the project of that name.
+The two are different things that happen to read alike, and merging them would make the highlight answer a question nobody asked.
+
+An assignment whose project could not be resolved keeps a `projectRef` and shows the raw reference as its title.
+It matches on the reference like any other assignment, which is the useful behaviour: every card broken by the same unreachable project lights up together.
+
+Titles are compared after trimming and otherwise exactly.
+Bare events that repeat carry the same `SUMMARY` verbatim, so normalising case or whitespace beyond a trim would only start matching events a planner did not mean to group.
+
+### An explicit toggle rather than hover
+
+Hover was the starting proposal and is rejected on timing rather than on noise.
+The planner hovers a card to learn where its project sits, then moves the pointer to that place to act, and the answer is gone before they arrive.
+A toggle survives the pointer leaving, which is the whole point.
+
+The toggle is one more button in the card action button row that the "open project in Daylite" change introduces.
+That change replaces the full-card click, which is what makes a per-card action possible at all: the card is a `<button>` today, so a second control inside it would be a nested button.
+
+Exactly one highlight is active.
+Activating the toggle on a card whose key is already active clears it, and every highlighted card carries the toggle, so an active highlight always shows at least one visible way to switch it off.
+That makes a separate dismiss affordance, an Escape binding or a toolbar control, redundant for now.
+
+### Emphasis by ring, not by dimming the rest
+
+Matching cards get a ring in a reserved color.
+Everything else in the grid is left alone.
+
+Dimming the non-matching cards would make the matches pop harder in a dense week, and it was the stronger option on legibility alone.
+It is deferred because it collides with three treatments that already use opacity for something else: the quick-add ghost at 50%, the lifted card during a drag, and the absence colors, which are themselves opacity-graded to separate the vacation and sick families.
+A ring composes with all of them, and dimming can be added later without changing what the highlight means.
+
+The ring color is a new theme-level token rather than one of the DaisyUI semantic colors.
+`primary` is the drop-target ring, `error` is the conflict ring, and `warning` already marks an unconfirmed calendar connection in the employee column.
+`accent` is unused in the grid but sits at hue 36 in the dark theme, close enough to the dark theme's error red at hue 30 to read as a warning.
+A dedicated token follows the precedent of `--color-absence-vacation` and its siblings, which were added for the same reason, and lets the hue be chosen for separation from the drop-target blue, the conflict red, and the three absence hues in both themes.
+
+### State at the grid root
+
+The active key lives in `PlanningGridTable` and travels to `TimetableCell` on the path `dropPreview` and `draggedUid` already take.
+A React context would spare the two intermediate components a prop, at the cost of a second way of moving grid state that the drag path does not use.
+
+The key is cleared by comparing the rendered week start against the one the active key was set in, the way `TimetableRow` already clears its ghost.
+This covers arrow navigation and the trackpad swipe without either having to know about the highlight, including the edge-hover navigation that changes the week mid-drag.
+
+Nothing else clears it.
+A reload rewrites events but not project references or titles, so the highlight lands on the reloaded cards.
+Dragging a highlighted card to another employee or day carries its key with it, so it stays highlighted where it lands.
+A highlight whose key no longer matches anything, because the last matching assignment was deleted, simply marks nothing and is replaced by the next activation.
+
+## Risks / Trade-offs
+
+- The toggle adds a control to every assignment and bare card in a grid that can hold many.
+  The card action button row is sized for this by the change that introduces it, and the mitigation belongs there rather than here.
+- A ring alone may be too quiet in a dense week.
+  Dimming the non-matching cards is the escalation, and the decision above keeps it available.
+- Title matching for bare events is as good as the titles are.
+  Two unrelated events both called "Besprechung" will match, which is a visible and self-correcting surprise rather than a silent one.
+
+## Migration Plan
+
+Not applicable.
+Nothing is persisted and no stored data changes.
+
+## Open Questions
+
+None.

--- a/openspec/changes/highlight-matching-events/proposal.md
+++ b/openspec/changes/highlight-matching-events/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+Planning a future week means answering "where else is this project already scheduled" over and over.
+The grid gives no way to ask it.
+A planner reads the week employee by employee and reconstructs a project's footprint from the card titles, which is exactly the kind of scanning the grid was supposed to remove.
+
+The Daylite category color on a card's left strip does not answer it either.
+Two different projects in the same Daylite category share a strip color, so the strip narrows the search without ever finishing it.
+
+Hovering a card is the obvious trigger and the wrong one.
+A hover highlight fires while the pointer sweeps across cards that were never the question, and it disappears at the moment it becomes useful: the planner moves the pointer away from the card to act on what the highlight just told them.
+An explicit toggle on the card is invoked deliberately, stays up while the planner works, and is dismissed deliberately.
+
+## What Changes
+
+- Assignment and bare event cards gain a highlight toggle among the card action buttons.
+  Activating it marks every other card in the visible week that carries the same work.
+- Matching is by Daylite project reference for assignment cards, so a project renamed in Daylite still matches and two projects sharing a name never do.
+- Matching is by event title for bare events, which carry no Daylite reference and have nothing else to be identified by.
+- An assignment and a bare event never match each other, even when the project name and the event title are identical.
+- Absence cards get no toggle and are never highlighted.
+  Absence types already have their own colors, so an absence is found by looking rather than by asking.
+- One highlight is active at a time.
+  Activating the toggle on a card of another project or title replaces it; activating it again on a card that is already highlighted clears it.
+- The highlight spans every employee row and every visible day of the current week, and marks cards only.
+  Day headers and the employee column are unaffected.
+- Navigating to another week clears the highlight, by arrow or by trackpad swipe.
+  Reloading assignments does not, because the highlight is keyed by project reference or title rather than by event UID, so it survives every event the reload rewrites.
+
+## Capabilities
+
+### New Capabilities
+
+- `event-highlighting`: marking every card in the visible week that shares the project or title of a card the planner picked.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Depends on the card action buttons introduced by the "open project in Daylite" change, which replace the full card click.
+  This change adds one button to that row and does not introduce the row itself.
+- `src/app/types.ts`: a highlight key derived from a `CellEvent`, kind-scoped so assignments and bare events cannot collide, and null for absences.
+- `src/app/page.tsx`: the active highlight key as root state, threaded to the cells along the path `dropPreview` and `draggedUid` already take, and cleared when the week changes.
+- `src/app/components/week-table.tsx` and `src/app/components/timetable-row.tsx`: pass the active key and the toggle handler through.
+- `src/app/components/timetable-cell.tsx`: the toggle button on assignment and bare cards, and the ring on cards whose key matches.
+- `src/app.css`: one theme-level color token for the highlight, reserved for this purpose and separated from the drop-target blue, the conflict red, and the three absence hues in both themes.
+- No backend change.
+  `projectRef` and `title` already reach the frontend on every `CalendarCellEvent`, and the highlight is never persisted.
+- Tests: `bun test` coverage for the key derivation, the kind scoping, the toggle semantics, the week-change clearing, and the rendered ring.

--- a/openspec/changes/highlight-matching-events/specs/event-highlighting/spec.md
+++ b/openspec/changes/highlight-matching-events/specs/event-highlighting/spec.md
@@ -1,0 +1,136 @@
+## ADDED Requirements
+
+### Requirement: Highlight toggle on event cards
+The system SHALL offer a highlight toggle among the action buttons of every assignment and bare event card.
+Absence cards SHALL NOT offer it.
+The toggle carries a German label naming what it matches, and reads as pressed while its card is highlighted.
+
+#### Scenario: Assignment card offers the toggle
+- **WHEN** a card for an assignment is rendered
+- **THEN** its action buttons include a highlight toggle
+
+#### Scenario: Bare event card offers the toggle
+- **WHEN** a card for a bare event is rendered
+- **THEN** its action buttons include a highlight toggle
+
+#### Scenario: Absence card offers no toggle
+- **WHEN** a card for an absence is rendered
+- **THEN** it has no highlight toggle
+
+#### Scenario: Active toggle reads as pressed
+- **WHEN** a highlight is active
+- **THEN** the toggle on every highlighted card reads as pressed to assistive technology
+
+### Requirement: Matching by project reference or title
+The system SHALL treat two events as the same work when they have the same kind and the same identifier for that kind.
+An assignment is identified by its Daylite project reference, a bare event by its title compared after trimming, and an absence by nothing.
+An assignment and a bare event SHALL NOT match each other.
+
+#### Scenario: Assignments of the same project match
+- **WHEN** the highlight is activated on an assignment
+- **THEN** every assignment in the week with the same Daylite project reference is highlighted
+
+#### Scenario: A renamed project still matches
+- **GIVEN** a project was renamed in Daylite after some of its assignments were created
+- **WHEN** the highlight is activated on one of its assignments
+- **THEN** every assignment holding that project reference is highlighted regardless of the title shown on the card
+
+#### Scenario: Assignments of different projects with the same name do not match
+- **GIVEN** two Daylite projects have the same name
+- **WHEN** the highlight is activated on an assignment of one of them
+- **THEN** assignments of the other project are not highlighted
+
+#### Scenario: An unresolved assignment matches on its reference
+- **GIVEN** an assignment whose Daylite project could not be resolved, so its card shows the raw reference
+- **WHEN** the highlight is activated on it
+- **THEN** every assignment holding the same reference is highlighted, resolved or not
+
+#### Scenario: Bare events with the same title match
+- **WHEN** the highlight is activated on a bare event
+- **THEN** every bare event in the week whose trimmed title is identical is highlighted
+
+#### Scenario: A bare event does not match an assignment
+- **GIVEN** a bare event whose title equals the name of a Daylite project scheduled in the same week
+- **WHEN** the highlight is activated on that bare event
+- **THEN** the assignments of that project are not highlighted
+
+#### Scenario: Absences are never highlighted
+- **WHEN** any highlight is active
+- **THEN** no absence card is highlighted
+
+### Requirement: Highlight scope
+The system SHALL apply an active highlight to the cards of every employee row and every visible day of the week on screen.
+Only cards SHALL change appearance.
+
+#### Scenario: Matching cards across employees are highlighted
+- **GIVEN** the same project is scheduled for several employees in the visible week
+- **WHEN** the highlight is activated on one of its cards
+- **THEN** the matching cards in every employee row are highlighted
+
+#### Scenario: Matching cards across days are highlighted
+- **GIVEN** the same project is scheduled on several days of the visible week
+- **WHEN** the highlight is activated on one of its cards
+- **THEN** the matching cards on every visible day are highlighted
+
+#### Scenario: Nothing outside the cards changes
+- **WHEN** a highlight is active
+- **THEN** the day headers, the employee column, and the cell backgrounds are unchanged
+
+### Requirement: One highlight at a time
+The system SHALL keep at most one highlight active.
+Activating the toggle on a card that is not highlighted replaces any active highlight with that card's.
+Activating it on a card that is highlighted clears the highlight.
+
+#### Scenario: Activating on another card replaces the highlight
+- **GIVEN** a highlight is active for one project
+- **WHEN** the user activates the toggle on a card of another project
+- **THEN** only the cards of the other project are highlighted
+
+#### Scenario: Activating on a highlighted card clears the highlight
+- **GIVEN** a highlight is active
+- **WHEN** the user activates the toggle on any highlighted card
+- **THEN** no card is highlighted
+
+### Requirement: Highlight lifetime
+The system SHALL clear the highlight when the grid shows another week, and SHALL keep it across every other change to the grid.
+
+#### Scenario: Week navigation clears the highlight
+- **GIVEN** a highlight is active
+- **WHEN** the user navigates to another week by arrow or by trackpad swipe
+- **THEN** no card is highlighted
+
+#### Scenario: Reloading assignments keeps the highlight
+- **GIVEN** a highlight is active
+- **WHEN** the assignments of the visible week are reloaded
+- **THEN** the reloaded cards that match are highlighted
+
+#### Scenario: A dragged card stays highlighted where it lands
+- **GIVEN** a highlight is active
+- **WHEN** the user drags a highlighted card to another day or employee in the same week
+- **THEN** the card is highlighted in its new position
+
+#### Scenario: A highlight matching nothing marks nothing
+- **GIVEN** a highlight is active
+- **WHEN** the last matching event of the visible week is deleted
+- **THEN** no card is highlighted and the grid is otherwise unchanged
+
+#### Scenario: The highlight is not persisted
+- **WHEN** the application is restarted
+- **THEN** no highlight is active
+
+### Requirement: Highlight appearance
+The system SHALL mark a highlighted card with a ring in a color reserved for highlighting, distinguishable from the drop-target and conflict rings and from the absence colors in the light and the dark theme.
+The card's own colors, including the Daylite category strip, SHALL remain visible.
+
+#### Scenario: Highlighted card is ringed
+- **WHEN** a card matches the active highlight
+- **THEN** it is rendered with the highlight ring
+
+#### Scenario: The highlight ring is not the drop-target or conflict ring
+- **GIVEN** a highlight is active
+- **WHEN** a cell is a drop target or holds an absence conflict
+- **THEN** the cell's ring and the cards' highlight ring are distinguishable
+
+#### Scenario: Card colors survive the highlight
+- **WHEN** a card is highlighted
+- **THEN** its background color and its Daylite category strip are unchanged

--- a/openspec/changes/highlight-matching-events/tasks.md
+++ b/openspec/changes/highlight-matching-events/tasks.md
@@ -1,0 +1,33 @@
+## 0. Preconditions
+
+- [ ] 0.1 The "open project in Daylite" change is implemented, so cards carry an action button row and the full-card click has been replaced
+
+## 1. Highlight key
+
+- [ ] 1.1 Write failing tests for the key derived from a `CellEvent`: the project reference for an assignment, the trimmed title for a bare event, none for an absence, and no match between an assignment and a bare event that read alike
+- [ ] 1.2 Add the key derivation to `src/app/types.ts`
+
+## 2. Highlight color
+
+- [ ] 2.1 Add a theme-level color token for the highlight ring to `src/app.css`, in the light and the dark theme
+- [ ] 2.2 Verify its separation from the drop-target blue, the conflict red, and the three absence hues in both themes with the dataviz palette checks
+
+## 3. Toggle on the card
+
+- [ ] 3.1 Write failing tests asserting the toggle renders on assignment and bare cards, not on absence cards, and reads as pressed while its card is highlighted
+- [ ] 3.2 Add the toggle to the card action buttons in `src/app/components/timetable-cell.tsx` with a Lucide icon and a German label
+- [ ] 3.3 Write failing tests for the ring on matching cards and for the card's own background and category strip surviving it
+- [ ] 3.4 Render the ring on cards whose key matches the active one
+
+## 4. Grid state
+
+- [ ] 4.1 Write failing tests for the toggle semantics: activating on an unhighlighted card replaces the active highlight, activating on a highlighted card clears it
+- [ ] 4.2 Hold the active key in `PlanningGridTable` and thread it and the toggle handler through `week-table.tsx` and `timetable-row.tsx` to the cells, along the path `dropPreview` and `draggedUid` take
+- [ ] 4.3 Write a failing test for the highlight clearing when the grid shows another week
+- [ ] 4.4 Clear the active key when the rendered week start changes, the way `TimetableRow` clears its ghost
+
+## 5. Verification
+
+- [ ] 5.1 Add a grid-level test with mocked commands covering a highlight across several employees and days of one week
+- [ ] 5.2 Verify the highlight survives a reload of the visible week and follows a card dragged to another employee or day
+- [ ] 5.3 Verify a highlight whose matching events are all deleted marks nothing and leaves the grid otherwise unchanged


### PR DESCRIPTION
## Description

Planning-only change, no application code.
Adds the `highlight-matching-events` OpenSpec change with proposal, design, spec delta for a new `event-highlighting` capability, and tasks.

A planner reading a future week has no way to ask where a project is already scheduled.
The Daylite category strip cannot answer it either, because two projects in the same category share a strip color.
The change plans a highlight toggle among the card action buttons: activating it marks every card in the visible week that carries the same work.

Matching is by Daylite project reference for assignment cards and by trimmed title for bare events.
Absences are excluded, one highlight is active at a time, and it clears when the grid shows another week.

### Notable decisions

An explicit toggle rather than hover.
Hover was the starting idea and is rejected on timing rather than on noise: the planner hovers a card to learn where its project sits, then moves the pointer there to act, and the answer is gone before they arrive.

The match key is kind-scoped, so a bare event titled like a project never matches that project's assignments.
Assignments match on the project reference, which survives a rename in Daylite and keeps two projects that share a name distinct.
An assignment whose project could not be resolved matches on its reference like any other, so every card broken by the same unreachable project lights up together.

Emphasis by a ring on matching cards, with dimming of the non-matching ones deferred.
Dimming reads harder in a dense week but collides with three treatments that already use opacity: the quick-add ghost, the lifted card during a drag, and the opacity-graded absence colors.

The ring color is a new theme token rather than a DaisyUI semantic color.
`primary` is the drop-target ring, `error` is the conflict ring, `warning` marks an unconfirmed calendar connection, and `accent` sits at hue 36 in the dark theme, close enough to that theme's error red to read as a warning.

State lives at the grid root and travels the path `dropPreview` and `draggedUid` already take, and is cleared by comparing the rendered week start the way `TimetableRow` already clears its ghost.

### What to look out for

The change depends on the card action button row from the planned "open project in Daylite" change, which replaces the full-card click.
This is recorded as task 0.1 and in the proposal's Impact section.
The dependency is real rather than cosmetic: the card is a `<button>` today, so a control inside it would be a nested button.

Worth a second opinion on title matching for bare events.
Two unrelated events both called "Besprechung" will match, which the design accepts as a visible and self-correcting surprise.

## Reviewer checklist

- [x] `bunx openspec validate highlight-matching-events` passes
- [x] The match rules in the spec delta are the ones you want, in particular that an assignment and a bare event never match each other
- [x] The toggle semantics and the clearing rules match how you expect to use the highlight while planning
- [x] The dependency on the "open project in Daylite" card buttons is stated where you would look for it

---
_Generated by [Claude Code](https://claude.ai/code/session_011WKsbW3zxDhgLhPNrbfXjk)_