### PR TITLE
Add category editing to the assignment-edit-details change

### DIFF
--- a/openspec/changes/assignment-edit-details/design.md
+++ b/openspec/changes/assignment-edit-details/design.md
@@ -26,6 +26,7 @@ Whatever a planner types into a time field is therefore gone by the next write o
 - One place in the VEVENT for each new field, chosen so a planner editing the event in ZEP or another CalDAV client sees something sensible.
 - No write path can silently drop a field: the fields travel together through `AssignmentWrite`, so adding one to the struct forces every caller to supply it.
 - The allocator keeps sole ownership of an assignment's times; entering times by hand steers one write rather than creating a second, competing source of truth.
+- Daylite keeps sole ownership of what a category is; the planner picks from the categories it defines and never invents one.
 
 **Non-Goals:**
 
@@ -39,6 +40,9 @@ Whatever a planner types into a time field is therefore gone by the next write o
 - Overlap detection between an assignment and the employee's bare or absence events.
 - Editing bare events or absences.
   They stay read-only, as they are today.
+- Creating a category, renaming one, or changing its color.
+  Those stay in Daylite, and so does removing a project's category altogether.
+- A category that belongs to a single appointment instead of to its project.
 
 ## Decisions
 
@@ -83,6 +87,46 @@ The note is what remains after dropping the first line and any single blank line
 Alternatives considered.
 An `X-LKR-NOTE` property keeps the description clean but hides the note from every other calendar client, which is the main reason to store it on the event at all.
 Moving the project reference to an X-property and giving `DESCRIPTION` entirely to the note would be cleaner, but every assignment already on a calendar carries the reference in the description, so it would need a migration and would break older events.
+
+### The category is the project's, so the picker writes it to Daylite
+
+A category in this application is not a property of a calendar event.
+`resolve_event` takes it from the resolved Daylite project to color the card, and `fixed-appointment-protection` reads the same field to decide whether an event may be changed at all.
+The picker therefore writes where the category already lives: saving a picked category sends `PATCH /projects/<id>` with the category's name, the way `update_contact_ical_urls_core` patches a contact's urls today, and Daylite carries a project's category as a plain name on the record, so the name is what goes on the wire.
+
+Two consequences follow from writing the project rather than the event, and both are features rather than side effects.
+Every appointment of that project changes color, on every week and every employee, which is why the modal carries a German hint saying the category belongs to the project.
+And picking `"Termin FIX geplant"` makes the project a fixed appointment, which locks that assignment and every other one referencing the project, exactly as a category set in Daylite does today; picking another category releases them again.
+Nothing in the protection rules changes: they keep reading the project's category, and now the planner has a second place to set it.
+
+Alternatives considered.
+A category of its own on the event, stored in an X-property like the title override, keeps one appointment's color independent of the project and is the shape the title and the note take in this change.
+It is rejected because it forks what a category means: protection would keep following the project while the card followed the event, and a planner could recolor a fixed appointment to something that looks unfixed with nothing in Daylite recording it.
+Offering the category read-only, so the modal shows the project's category without letting it be changed, was the smaller change, but it leaves the planner with the same trip into Daylite that this change is meant to remove.
+
+### The calendar write goes first, and the category write refreshes the cached project
+
+A save that changes both the assignment and its category has to order the two writes, and only one order works.
+`update_assignment` refuses a write to a protected event, so a category write that landed first would make the assignment fixed and then refuse the very save that set it.
+The modal therefore writes the assignment to the calendar first and the category to Daylite second.
+
+A category write that fails after the calendar write succeeded leaves the calendar changes in place and reports the German error in the modal; the project keeps the category it had, so a retry is the whole recovery and there is no half-written state to repair.
+
+`project_cache` holds a resolved project for 30 seconds, which is long enough for the reload after a save to show the old color and, worse, the old protection verdict.
+So the write replaces the cache entry for the reference it touched instead of waiting the TTL out: the reload shows the new color, and an assignment just made fixed is refused from that moment.
+
+### The picker lists what Daylite offers, colorless categories included and retired ones left out
+
+`/categories?entity=project` is read into a name-to-color map today, and a category without a `hex_colour` is dropped, because a missing color is all the grid needs to know about it.
+A picker needs the names, so the read returns the list -- each category's name, its color when it has one, and whether it is still active -- and the frontend derives the color lookup it already had from that same list.
+One read serves the grid coloring, the project picker, and the category picker, and a category nobody gave a color is offered with the neutral color rather than being invisible.
+The list is sorted by name so it does not depend on the order the API happens to return.
+
+Categories with `is_active` false are not offered.
+Daylite keeps them so projects that still reference them stay colored, which is why they remain in the color lookup, but handing a planner a retired category to assign afresh spreads something its owner deliberately withdrew.
+
+Clearing a project's category is not offered either.
+The picker holds the categories Daylite has; a project that should carry none is a Daylite edit, and no planner has asked for it.
 
 ### Times entered by hand steer one write and are stored nowhere
 
@@ -157,6 +201,12 @@ Times entered by hand do not, and are not meant to.
 
 [Adjacent adjustment writes up to three events, so a partial failure leaves the day half-adjusted] → The neighbours go through `patch_event_slot`, the same multi-event path re-allocation already uses, so the failure mode is the one the planner already has for a failed re-slot: a reload shows the true state.
 
+[A planner reads the category picker as recoloring one appointment and repaints a project used across the whole grid] → The German hint under the picker says the category is the project's, and the reload after the save shows the project's other cards in the new color, which is the correction if the hint was missed.
+
+[Picking `"Termin FIX geplant"` locks the assignment the planner is editing] → That is what the category means, and the lock is undone the way every other one is: unlock the appointment and pick another category. The modal is the only new way in, not a new kind of lock.
+
+[Daylite may reject the category name, or expect a reference rather than a name] → The name written is one Daylite itself returned from `/categories`, and a rejection surfaces as the normalized German error rather than being swallowed. The request shape is pinned by a cassette test before the modal is built on it.
+
 [Skipping the even split for one write leaves a day overlapping until something re-allocates it] → That is the feature working; the state is legal iCal and the next ordinary write on that day tidies it.
 
 ## Migration Plan
@@ -165,3 +215,4 @@ No data migration.
 Events written before this change carry no `X-LKR-TITLE` and no note, both are optional, and nothing about how times are stored changes, so existing assignments load, save, and allocate exactly as they do today.
 An older build of the planner reading an event written by the new one shows the override as the card title only when the project fails to resolve and rewrites the event without the note, so a rollback loses titles and notes on the assignments touched after it.
 Entered times need no rollback story at all: they were never stored as anything but ordinary `DTSTART` and `DTEND`.
+A project's category is Daylite's data and is read the same way before and after this change, so a rollback simply removes the second place it can be set.

--- a/openspec/changes/assignment-edit-details/design.md
+++ b/openspec/changes/assignment-edit-details/design.md
@@ -41,7 +41,7 @@ Whatever a planner types into a time field is therefore gone by the next write o
 - Editing bare events or absences.
   They stay read-only, as they are today.
 - Creating a category, renaming one, or changing its color.
-  Those stay in Daylite, and so does removing a project's category altogether.
+  Those stay in Daylite.
 - A category that belongs to a single appointment instead of to its project.
 
 ## Decisions
@@ -125,8 +125,11 @@ The list is sorted by name so it does not depend on the order the API happens to
 Categories with `is_active` false are not offered.
 Daylite keeps them so projects that still reference them stay colored, which is why they remain in the color lookup, but handing a planner a retired category to assign afresh spreads something its owner deliberately withdrew.
 
-Clearing a project's category is not offered either.
-The picker holds the categories Daylite has; a project that should carry none is a Daylite edit, and no planner has asked for it.
+The picker's first entry removes the category instead of setting one.
+A category picked by mistake would otherwise need a trip into Daylite to undo, which is the trip this change exists to remove, and a project carrying no category is an ordinary state: `resolve_event` already returns `None` for it and the card falls back to the neutral color.
+Removing is written as the same `PATCH /projects/<id>` with a null category, so it is one write path with one error message rather than two.
+
+It follows that removing the category of a project carrying `"Termin FIX geplant"` releases its appointments, exactly as picking another category does: protection asks whether the category equals the fixed one, and no category does not.
 
 ### Times entered by hand steer one write and are stored nowhere
 

--- a/openspec/changes/assignment-edit-details/proposal.md
+++ b/openspec/changes/assignment-edit-details/proposal.md
@@ -19,7 +19,8 @@ Marking a job as a fixed appointment is the same story from the other side: the 
 - The edit modal gains a free-text note that is written into the event DESCRIPTION below the `daylite:` reference line, so it reaches every calendar client reading the event.
 - The edit modal gains a category picker holding the project categories Daylite offers, each shown with its name and its color, and saving gives the assignment's Daylite project the picked category.
   The category is the project's, so it applies to every appointment of that project, which a German hint in the modal says out loud.
-  A fixed appointment is one whose project carries the category `"Termin FIX geplant"`, so picking that category locks the assignment and picking another releases it.
+  The picker's first entry removes the project's category again, for a category picked by mistake.
+  A fixed appointment is one whose project carries the category `"Termin FIX geplant"`, so picking that category locks the assignment, and picking another or removing it releases it.
   Creating categories and editing their names or colors stays in Daylite.
 - Title override and note survive every write that rewrites the event: saving the modal, rescheduling by drag, moving to another employee, and slot re-allocation.
   **BREAKING** for `move_assignment`, `update_assignment`, and `create_assignment`: their inputs grow the new fields, and a caller that omits them drops the data.
@@ -35,7 +36,7 @@ None.
 - `assignment-modal-crud`: the modal edits date, start and end time, title, note, and the project's category in addition to the project itself, and its unsaved-changes and validation rules cover the new fields.
 - `slot-allocation`: a write can carry times entered by a planner instead of applying the even split, and can fit the day's adjacent assignments to them; those times last only until the day is next re-allocated.
 - `assignment-persistence`: assignment events carry a title override and a planner note, and every write path preserves them instead of rebuilding the VEVENT from the project alone.
-- `daylite-integration`: the project categories are read as a list carrying each category's name and color, and a project's category can be set.
+- `daylite-integration`: the project categories are read as a list carrying each category's name and color, and a project's category can be set and removed.
 - `fixed-appointment-protection`: a category set from the planner decides protection right away, instead of the category cached before the write.
 
 ## Impact

--- a/openspec/changes/assignment-edit-details/proposal.md
+++ b/openspec/changes/assignment-edit-details/proposal.md
@@ -3,6 +3,7 @@
 The edit modal can only swap the project behind an assignment.
 Everything else a planner knows about a job -- which day it really belongs on, when it actually happens, a title that says more than the project name, a note for the person on site -- has to live outside the planner, so the calendar entry the employee sees in ZEP stays a bare project name in a slot the allocator picked.
 Rescheduling already works by dragging a card, but a planner who opens the modal to correct a date has no way to do it there, and nobody can say that a job starts at 07:00 or runs until 18:00.
+Marking a job as a fixed appointment is the same story from the other side: the category that decides it lives in Daylite, so a planner who wants to pin a date has to leave the planner to do it.
 
 ## What Changes
 
@@ -16,6 +17,10 @@ Rescheduling already works by dragging a card, but a planner who opens the modal
 - The edit modal gains a title field, shown alongside the project field so the custom title and the Daylite project name are both visible.
   An empty title field means no override and the Daylite project name is used, including when it is renamed in Daylite; a title typed into the field replaces it everywhere the assignment is shown.
 - The edit modal gains a free-text note that is written into the event DESCRIPTION below the `daylite:` reference line, so it reaches every calendar client reading the event.
+- The edit modal gains a category picker holding the project categories Daylite offers, each shown with its name and its color, and saving gives the assignment's Daylite project the picked category.
+  The category is the project's, so it applies to every appointment of that project, which a German hint in the modal says out loud.
+  A fixed appointment is one whose project carries the category `"Termin FIX geplant"`, so picking that category locks the assignment and picking another releases it.
+  Creating categories and editing their names or colors stays in Daylite.
 - Title override and note survive every write that rewrites the event: saving the modal, rescheduling by drag, moving to another employee, and slot re-allocation.
   **BREAKING** for `move_assignment`, `update_assignment`, and `create_assignment`: their inputs grow the new fields, and a caller that omits them drops the data.
 
@@ -27,14 +32,18 @@ None.
 
 ### Modified Capabilities
 
-- `assignment-modal-crud`: the modal edits date, start and end time, title, and note in addition to the project, and its unsaved-changes and validation rules cover the new fields.
+- `assignment-modal-crud`: the modal edits date, start and end time, title, note, and the project's category in addition to the project itself, and its unsaved-changes and validation rules cover the new fields.
 - `slot-allocation`: a write can carry times entered by a planner instead of applying the even split, and can fit the day's adjacent assignments to them; those times last only until the day is next re-allocated.
 - `assignment-persistence`: assignment events carry a title override and a planner note, and every write path preserves them instead of rebuilding the VEVENT from the project alone.
+- `daylite-integration`: the project categories are read as a list carrying each category's name and color, and a project's category can be set.
+- `fixed-appointment-protection`: a category set from the planner decides protection right away, instead of the category cached before the write.
 
 ## Impact
 
 - Backend: `integrations/calendar/ical.rs` (payload building gains title override and note; parsing gains the new properties), `integrations/calendar/slots.rs` (a write can carry requested times instead of the even split; adjacent adjustment), `caldav/write.rs` (`AssignmentWrite` grows the new fields), `calendar/commands.rs` (command inputs gain the requested times and the adjustment flag), `events/classify.rs` and `events/resolve.rs` (note and title override reach the frontend), `calendar/types.rs` (`CalendarCellEvent`).
-- Frontend: `components/assignment-modal.tsx`, `hooks/use-assignment-modal.ts`, `hooks/use-appointment-drag.ts` (drag writes must carry the preserved fields), `app/types.ts`.
+- Backend (Daylite): `integrations/daylite/categories.rs` (the category read returns a list), `integrations/daylite/projects.rs` (a project's category can be set, and the cached project follows the write).
+- Frontend: `components/assignment-modal.tsx`, `hooks/use-assignment-modal.ts`, `hooks/use-appointment-drag.ts` (drag writes must carry the preserved fields), `services/daylite-categories.ts` (the color lookup is derived from the category list), `app/types.ts`.
 - Generated Tauri bindings in `src/generated/tauri.ts` are regenerated.
 - No new Rust or npm dependency.
+- Saving the modal can now write to Daylite as well as to the calendar, which is the first write this application makes to a project.
 - Slot re-allocation gains a second mode: a write can skip the even split for one day, which can leave that day with gaps or overlaps until the next ordinary write tidies it.

--- a/openspec/changes/assignment-edit-details/specs/assignment-modal-crud/spec.md
+++ b/openspec/changes/assignment-edit-details/specs/assignment-modal-crud/spec.md
@@ -155,6 +155,73 @@ The modal SHALL let the planner attach free-text notes to an assignment, stored 
 - **WHEN** an assignment with a note is loaded from the calendar
 - **THEN** it is still shown as an assignment card with its project's category color, not as a bare event
 
+### Requirement: Edit the assignment category
+The modal SHALL let the planner give the assignment's Daylite project one of the categories Daylite offers, picked from a list showing each category with its name and its color.
+The category belongs to the project rather than to the single assignment, so it changes for every appointment of that project, and because a fixed appointment is one whose project carries the category `"Termin FIX geplant"`, picking that category locks the assignment and picking another releases it.
+
+#### Scenario: The picker lists the categories Daylite offers
+- **WHEN** the modal is open
+- **THEN** a category picker offers the project categories loaded from Daylite
+- **AND** each is shown with its name and the color Daylite holds for it
+- **AND** a category Daylite gives no color is shown with the neutral color
+
+#### Scenario: Picker shows the project's current category
+- **WHEN** the modal opens for an assignment whose Daylite project carries a category
+- **THEN** that category is the selected one
+
+#### Scenario: Project without a category
+- **WHEN** the modal opens for an assignment whose Daylite project carries no category
+- **THEN** no category is selected
+- **AND** a German placeholder says so
+
+#### Scenario: Save a category
+- **WHEN** the planner picks a different category and saves
+- **THEN** the assignment's Daylite project is given that category
+- **AND** the card is shown in the new category's color after the reload
+
+#### Scenario: The planner is told the category belongs to the project
+- **WHEN** the category picker is shown
+- **THEN** a German hint explains that the category is the project's and applies to all of its appointments
+
+#### Scenario: Every appointment of the project follows the change
+- **WHEN** the planner changes the category of a project other assignments in the grid also reference
+- **THEN** those assignments are shown in the new category's color after the reload
+
+#### Scenario: Switching project shows that project's category
+- **WHEN** the planner picks a different project
+- **THEN** the picker shows the newly selected project's category
+
+#### Scenario: Saving without touching the category
+- **WHEN** the planner changes only the project, date, times, title, or note and saves
+- **THEN** nothing is written to Daylite
+- **AND** the project keeps the category it had
+
+#### Scenario: The category is written after the calendar changes
+- **WHEN** a save changes both the assignment and its category
+- **THEN** the assignment is written to the calendar first
+- **AND** the category is written to Daylite afterwards
+
+#### Scenario: Writing the category fails
+- **WHEN** writing the category to Daylite fails
+- **THEN** a German error message is shown in the modal
+- **AND** the assignment's calendar changes stay written
+- **AND** the project keeps the category it had
+
+#### Scenario: Picking the fixed category locks the assignment
+- **WHEN** the planner picks the category `"Termin FIX geplant"` and saves
+- **THEN** the assignment is protected from then on
+- **AND** reopening the modal shows the German fixed-appointment notice with its unlock control
+
+#### Scenario: Picking another category releases the lock
+- **WHEN** the planner unlocks a protected assignment, picks another category, and saves
+- **THEN** the assignment is no longer protected
+- **AND** it can be edited, moved to another day, and deleted again
+
+#### Scenario: Create with a category
+- **WHEN** the planner picks a category before saving a new assignment
+- **THEN** the assignment is created
+- **AND** the project it references is given that category
+
 ## MODIFIED Requirements
 
 ### Requirement: Unsaved changes handling
@@ -166,7 +233,7 @@ The system SHALL handle unsaved changes properly.
 - **AND** user can save, discard, or cancel
 
 #### Scenario: Editing any field marks the modal dirty
-- **WHEN** the planner changes the project, the date, either time, the title, or the note
+- **WHEN** the planner changes the project, the date, either time, the title, the note, or the category
 - **THEN** closing the modal shows the unsaved-changes confirmation
 
 #### Scenario: Toggling the adjustment checkbox alone does not
@@ -199,6 +266,7 @@ The system SHALL allow editing an existing assignment, unless it is protected be
 #### Scenario: Save leaves untouched fields alone
 - **WHEN** the planner changes one field and saves
 - **THEN** the assignment's other fields -- project, date, times, title, note -- are written back unchanged
+- **AND** its Daylite project keeps the category it had
 - **AND** its position among the day's assignments is unchanged
 
 #### Scenario: Save fails

--- a/openspec/changes/assignment-edit-details/specs/assignment-modal-crud/spec.md
+++ b/openspec/changes/assignment-edit-details/specs/assignment-modal-crud/spec.md
@@ -156,8 +156,8 @@ The modal SHALL let the planner attach free-text notes to an assignment, stored 
 - **THEN** it is still shown as an assignment card with its project's category color, not as a bare event
 
 ### Requirement: Edit the assignment category
-The modal SHALL let the planner give the assignment's Daylite project one of the categories Daylite offers, picked from a list showing each category with its name and its color.
-The category belongs to the project rather than to the single assignment, so it changes for every appointment of that project, and because a fixed appointment is one whose project carries the category `"Termin FIX geplant"`, picking that category locks the assignment and picking another releases it.
+The modal SHALL let the planner give the assignment's Daylite project one of the categories Daylite offers, picked from a list showing each category with its name and its color, and SHALL let the planner remove the category the project carries.
+The category belongs to the project rather than to the single assignment, so it changes for every appointment of that project, and because a fixed appointment is one whose project carries the category `"Termin FIX geplant"`, picking that category locks the assignment while picking another or removing it releases it.
 
 #### Scenario: The picker lists the categories Daylite offers
 - **WHEN** the modal is open
@@ -165,19 +165,28 @@ The category belongs to the project rather than to the single assignment, so it 
 - **AND** each is shown with its name and the color Daylite holds for it
 - **AND** a category Daylite gives no color is shown with the neutral color
 
+#### Scenario: The picker offers removing the category
+- **WHEN** the category picker is shown
+- **THEN** its first entry is a German option for no category
+- **AND** it is shown with the neutral color
+
 #### Scenario: Picker shows the project's current category
 - **WHEN** the modal opens for an assignment whose Daylite project carries a category
 - **THEN** that category is the selected one
 
 #### Scenario: Project without a category
 - **WHEN** the modal opens for an assignment whose Daylite project carries no category
-- **THEN** no category is selected
-- **AND** a German placeholder says so
+- **THEN** the entry for no category is the selected one
 
 #### Scenario: Save a category
 - **WHEN** the planner picks a different category and saves
 - **THEN** the assignment's Daylite project is given that category
 - **AND** the card is shown in the new category's color after the reload
+
+#### Scenario: Remove the category
+- **WHEN** the planner picks the entry for no category and saves
+- **THEN** the assignment's Daylite project carries no category afterwards
+- **AND** the card falls back to the neutral color after the reload
 
 #### Scenario: The planner is told the category belongs to the project
 - **WHEN** the category picker is shown
@@ -213,7 +222,7 @@ The category belongs to the project rather than to the single assignment, so it 
 - **AND** reopening the modal shows the German fixed-appointment notice with its unlock control
 
 #### Scenario: Picking another category releases the lock
-- **WHEN** the planner unlocks a protected assignment, picks another category, and saves
+- **WHEN** the planner unlocks a protected assignment, picks another category or the entry for no category, and saves
 - **THEN** the assignment is no longer protected
 - **AND** it can be edited, moved to another day, and deleted again
 

--- a/openspec/changes/assignment-edit-details/specs/daylite-integration/spec.md
+++ b/openspec/changes/assignment-edit-details/specs/daylite-integration/spec.md
@@ -1,13 +1,18 @@
 ## ADDED Requirements
 
 ### Requirement: Set a project's category
-The system SHALL set a Daylite project's category to one of the categories Daylite offers for projects.
+The system SHALL set a Daylite project's category to one of the categories Daylite offers for projects, and SHALL remove the category a project carries.
 Creating a category, renaming one, and changing a category's color stay Daylite's business and are not offered here.
 
 #### Scenario: Write the picked category
 - **WHEN** a project's category is set to a category Daylite offers
 - **THEN** the system sends `PATCH /projects/<id>` carrying that category's name
 - **AND** the write is reported as successful only once Daylite accepted it
+
+#### Scenario: Remove the category
+- **WHEN** a project's category is removed
+- **THEN** the system sends `PATCH /projects/<id>` carrying a null category
+- **AND** the project carries no category afterwards
 
 #### Scenario: Daylite rejects the write
 - **WHEN** Daylite rejects setting the category

--- a/openspec/changes/assignment-edit-details/specs/daylite-integration/spec.md
+++ b/openspec/changes/assignment-edit-details/specs/daylite-integration/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Set a project's category
+The system SHALL set a Daylite project's category to one of the categories Daylite offers for projects.
+Creating a category, renaming one, and changing a category's color stay Daylite's business and are not offered here.
+
+#### Scenario: Write the picked category
+- **WHEN** a project's category is set to a category Daylite offers
+- **THEN** the system sends `PATCH /projects/<id>` carrying that category's name
+- **AND** the write is reported as successful only once Daylite accepted it
+
+#### Scenario: Daylite rejects the write
+- **WHEN** Daylite rejects setting the category
+- **THEN** the normalized German error message is returned
+- **AND** the project keeps the category it had
+
+#### Scenario: The cached project follows the write
+- **WHEN** a project's category has been set
+- **THEN** the cached project for that reference carries the new category
+- **AND** the next resolution of that reference returns it without waiting for the cache entry to expire
+
+## MODIFIED Requirements
+
+### Requirement: Category color retrieval
+The system SHALL retrieve the Daylite categories a project can carry, with their colors, for coloring project events and for offering the categories a project can be given.
+
+#### Scenario: Fetch project categories
+- **WHEN** the project categories are requested
+- **THEN** the system requests `GET /categories` with the `entity=project` filter
+- **AND** parses `name`, `hex_colour`, and `is_active` for each category
+
+#### Scenario: The categories are returned as a list
+- **WHEN** the frontend requests the project categories
+- **THEN** a list carrying each category's name, its color, and whether it is still active, sorted by name, is returned as a typed command result
+- **AND** a failure yields no categories rather than a user-facing error
+
+#### Scenario: One map serves the grid and the assignment modal
+- **WHEN** the frontend colors an event or a project result by its category
+- **THEN** the name-to-color map it reads is derived from that one list
+- **AND** the planning grid, the project picker, and the category picker all read the categories from that same list
+
+#### Scenario: Category without a color
+- **WHEN** a category's `hex_colour` is null
+- **THEN** the category is listed without a color
+- **AND** events of projects in that category fall back to the neutral color
+
+#### Scenario: Overdue results carry their category
+- **WHEN** overdue projects are queried
+- **THEN** each result carries the category `"Überfällig"` the query filtered on, even though Daylite omits the field from these minimal records
+
+#### Scenario: Inactive categories keep their color
+- **WHEN** a category has `is_active` set to false
+- **AND** an existing project still references that category
+- **THEN** the category's color is still used for that project's events
+- **AND** the category is not offered as one a project can be given

--- a/openspec/changes/assignment-edit-details/specs/fixed-appointment-protection/spec.md
+++ b/openspec/changes/assignment-edit-details/specs/fixed-appointment-protection/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: A category set from the planner protects at once
+The category deciding whether an event is protected is the linked Daylite project's, so setting it from the planner locks or releases every event referencing that project.
+The system SHALL apply the protection rules to the category a project was just given rather than to the one cached before the write.
+
+#### Scenario: Newly fixed project protects its events
+- **WHEN** a project is given the category `"Termin FIX geplant"` from the planner
+- **THEN** every event referencing that project is treated as protected from that moment
+- **AND** a following update, day change, or delete is refused with the German fixed-appointment message
+
+#### Scenario: Releasing the category releases the events
+- **WHEN** a project's category is changed from `"Termin FIX geplant"` to another category
+- **THEN** events referencing that project are no longer treated as protected
+- **AND** they can be edited, moved to another day, and deleted again
+
+#### Scenario: The save that sets the category is not refused by it
+- **WHEN** a save writes an assignment and gives its project the category `"Termin FIX geplant"`
+- **THEN** the assignment's calendar write is carried out before the category is written
+- **AND** it is not refused by the protection the new category creates

--- a/openspec/changes/assignment-edit-details/specs/fixed-appointment-protection/spec.md
+++ b/openspec/changes/assignment-edit-details/specs/fixed-appointment-protection/spec.md
@@ -10,7 +10,7 @@ The system SHALL apply the protection rules to the category a project was just g
 - **AND** a following update, day change, or delete is refused with the German fixed-appointment message
 
 #### Scenario: Releasing the category releases the events
-- **WHEN** a project's category is changed from `"Termin FIX geplant"` to another category
+- **WHEN** a project's category is changed from `"Termin FIX geplant"` to another category, or removed altogether
 - **THEN** events referencing that project are no longer treated as protected
 - **AND** they can be edited, moved to another day, and deleted again
 

--- a/openspec/changes/assignment-edit-details/tasks.md
+++ b/openspec/changes/assignment-edit-details/tasks.md
@@ -64,14 +64,14 @@
 
 - [ ] 9.1 Return the project categories from `/categories?entity=project` as a list carrying each category's name, its color, and whether it is still active, sorted by name
 - [ ] 9.2 Derive the name-to-color lookup in `services/daylite-categories.ts` from that one list, keeping retired categories in the lookup and out of the picker
-- [ ] 9.3 Add a Daylite command that sets a project's category by PATCHing `/projects/<id>` with the picked name, returning the normalized German error when Daylite rejects it
+- [ ] 9.3 Add a Daylite command that sets a project's category by PATCHing `/projects/<id>` with the picked name, or with a null category when the category is removed, returning the normalized German error when Daylite rejects it
 - [ ] 9.4 Replace the cached project for the written reference so the next resolution returns the new category instead of waiting out the cache lifetime, with a test that a project just made fixed is refused by `refuse_protected_event`
 - [ ] 9.5 Record a cassette for the category list and the category write, and pin the request shape against it
-- [ ] 9.6 Add category state to `use-assignment-modal`, initialised from the assignment's resolved project category and following the project when the planner picks a different one
-- [ ] 9.7 Send the category write only when the planner picked a different category, after the calendar write has succeeded, and show the German error in the modal when it fails while keeping the calendar changes
+- [ ] 9.6 Add category state to `use-assignment-modal`, initialised from the assignment's resolved project category, holding no category for a project without one, and following the project when the planner picks a different one
+- [ ] 9.7 Send the category write only when the planner picked a different category or removed it, after the calendar write has succeeded, and show the German error in the modal when it fails while keeping the calendar changes
 - [ ] 9.8 Extend the dirty tracking so a category change marks the modal changed
-- [ ] 9.9 Render the picker with the active categories, each with its name and color swatch, the neutral swatch for a category without a color, and the German hint that the category belongs to the project, using DaisyUI form controls and no nested `div`/`span`
-- [ ] 9.10 Add modal tests for each scenario in the `assignment-modal-crud` category delta, including that picking `"Termin FIX geplant"` leaves the reopened modal protected and that picking another category releases it
+- [ ] 9.9 Render the picker with the German entry for no category first, then the active categories, each with its name and color swatch, the neutral swatch for a category without a color, and the German hint that the category belongs to the project, using DaisyUI form controls and no nested `div`/`span`
+- [ ] 9.10 Add modal tests for each scenario in the `assignment-modal-crud` category delta, including that picking `"Termin FIX geplant"` leaves the reopened modal protected and that picking another category or removing it releases the assignment
 
 ## 10. Drag paths
 

--- a/openspec/changes/assignment-edit-details/tasks.md
+++ b/openspec/changes/assignment-edit-details/tasks.md
@@ -60,13 +60,26 @@
 - [ ] 8.5 Render the title and note fields so the project field's Daylite name stays visible next to the title
 - [ ] 8.6 Add modal tests for each scenario in the `assignment-modal-crud` delta
 
-## 9. Drag paths
+## 9. Category
 
-- [ ] 9.1 Pass the dragged card's custom title with the title it replaced, and its note, into the reschedule and move writes in `use-appointment-drag`, without requested times or adjacent adjustment
-- [ ] 9.2 Add tests that a reschedule and a move both carry the details through and write the standard window
+- [ ] 9.1 Return the project categories from `/categories?entity=project` as a list carrying each category's name, its color, and whether it is still active, sorted by name
+- [ ] 9.2 Derive the name-to-color lookup in `services/daylite-categories.ts` from that one list, keeping retired categories in the lookup and out of the picker
+- [ ] 9.3 Add a Daylite command that sets a project's category by PATCHing `/projects/<id>` with the picked name, returning the normalized German error when Daylite rejects it
+- [ ] 9.4 Replace the cached project for the written reference so the next resolution returns the new category instead of waiting out the cache lifetime, with a test that a project just made fixed is refused by `refuse_protected_event`
+- [ ] 9.5 Record a cassette for the category list and the category write, and pin the request shape against it
+- [ ] 9.6 Add category state to `use-assignment-modal`, initialised from the assignment's resolved project category and following the project when the planner picks a different one
+- [ ] 9.7 Send the category write only when the planner picked a different category, after the calendar write has succeeded, and show the German error in the modal when it fails while keeping the calendar changes
+- [ ] 9.8 Extend the dirty tracking so a category change marks the modal changed
+- [ ] 9.9 Render the picker with the active categories, each with its name and color swatch, the neutral swatch for a category without a color, and the German hint that the category belongs to the project, using DaisyUI form controls and no nested `div`/`span`
+- [ ] 9.10 Add modal tests for each scenario in the `assignment-modal-crud` category delta, including that picking `"Termin FIX geplant"` leaves the reopened modal protected and that picking another category releases it
 
-## 10. Verification
+## 10. Drag paths
 
-- [ ] 10.1 Run `cargo test`, `bun test`, and the Biome check
-- [ ] 10.2 Exercise the write path against the disposable Radicale server in `caldav/write.rs` with an assignment carrying a title override, a note, and requested times with adjacent adjustment
-- [ ] 10.3 Run `bunx openspec validate assignment-edit-details --strict`
+- [ ] 10.1 Pass the dragged card's custom title with the title it replaced, and its note, into the reschedule and move writes in `use-appointment-drag`, without requested times or adjacent adjustment
+- [ ] 10.2 Add tests that a reschedule and a move both carry the details through and write the standard window
+
+## 11. Verification
+
+- [ ] 11.1 Run `cargo test`, `bun test`, and the Biome check
+- [ ] 11.2 Exercise the write path against the disposable Radicale server in `caldav/write.rs` with an assignment carrying a title override, a note, and requested times with adjacent adjustment
+- [ ] 11.3 Run `bunx openspec validate assignment-edit-details --strict`


### PR DESCRIPTION
## Description

The `assignment-edit-details` change now also covers changing an event's category.
The edit modal gains a picker over the project categories Daylite offers, each shown with its name and its color, and saving gives the assignment's linked Daylite project the picked category.
The picker's first entry removes the project's category again.
Adding categories and editing their names or colors stays in Daylite.

Spec-only change, no code.

- `proposal.md`: the category bullet, `daylite-integration` and `fixed-appointment-protection` as modified capabilities, and the impacted Daylite files.
- `specs/assignment-modal-crud/spec.md`: new requirement `Edit the assignment category`, plus category added to the dirty tracking and to the "save leaves untouched fields alone" scenario.
- `specs/daylite-integration/spec.md` (new delta): the category read returns a list of name, color, and active flag; a project's category can be set and removed with `PATCH /projects/<id>`.
- `specs/fixed-appointment-protection/spec.md` (new delta): a category set from the planner decides protection right away instead of after the project cache expires.
- `design.md`: three decisions, the goals and non-goals they imply, and three risks.
- `tasks.md`: new section 9 with ten tasks; the drag and verification sections are renumbered to 10 and 11.

### Notable decisions

The category is the project's, not the event's, so the picker writes to Daylite rather than to the VEVENT.
`resolve_event` reads the category from the resolved project to color the card and `fixed-appointment-protection` reads the same field, so an event-level override would fork what a category means: the card would follow the event while the lock followed the project.
Writing the project instead means the category applies to every appointment of that project, which the modal says out loud in a German hint.

Picking `"Termin FIX geplant"` therefore locks the assignment, and picking another category or removing it releases the assignment again, exactly as setting the category in Daylite does today.
That forces the write order: `update_assignment` refuses a write to a protected event, so the calendar write goes first and the category write second, otherwise the category would refuse the very save that set it.
The write also replaces the cached project for the reference it touched, because the 30 second cache would otherwise serve the old color and the old protection verdict.

The category read returns a list rather than the name-to-color map it returns today, so the picker can offer categories Daylite gives no color, and the existing color lookup is derived from that same list.
Retired categories (`is_active` false) stay in the color lookup so existing projects keep their color, but are not offered in the picker.
Removing the category is written through the same PATCH with a null category, so setting and removing are one write path with one error message.

### What to look out for

Daylite carries a project's category as a plain name on the record, which is how it is parsed today, so the write sends the name.
Task 9.5 pins the actual request shape with a cassette before the modal is built on it, in case the API expects a reference instead, and the same cassette should confirm that a null category clears it.

Saving the modal can now write to Daylite as well as to the calendar, and it is the first write this application makes to a project.
A category write that fails after the calendar write succeeded leaves the calendar changes in place and reports the German error in the modal.

## Reviewer checklist

- [ ] `bunx openspec validate assignment-edit-details --strict` passes
- [ ] The category is the project's rather than the event's, and locking through `"Termin FIX geplant"` is the intended behaviour
- [ ] The picker's scope is right: no adding or editing of categories, retired categories hidden, removing the category offered as the first entry