### PR TITLE
Add event search by title change proposal

### DIFF
--- a/openspec/changes/search-events-by-title/.openspec.yaml
+++ b/openspec/changes/search-events-by-title/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/search-events-by-title/design.md
+++ b/openspec/changes/search-events-by-title/design.md
@@ -1,0 +1,93 @@
+## Context
+
+The only event read path today is `load_week_events` (`src-tauri/src/integrations/calendar/commands.rs`), which fans out over every configured employee's primary and absence calendar for one week.
+Under it, `fetch_events_in_range` (`src-tauri/src/integrations/calendar/caldav/report.rs`) already issues a CalDAV `REPORT` for an arbitrary date range; `fetch_calendar_events` is only the week-shaped wrapper around it.
+A search across many weeks therefore needs a new command, not a new transport.
+
+Titles reach the backend as the VEVENT `SUMMARY`; the Daylite project reference is carried separately in the `DESCRIPTION` as `daylite:/v1/projects/42`.
+This change searches titles only, so the Daylite side is untouched and no project resolution is needed for a result.
+
+The week the grid shows is `weekOffset` state in `src/app.tsx`, and the only navigation the grid exposes is `onNavigateWeek(direction: -1 | 1)`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Find events by a title fragment across a bounded range of past and future weeks.
+- Jump the grid to the week of a chosen result.
+- Report per-employee calendar failures without discarding the results that did succeed.
+
+**Non-Goals:**
+- No search by Daylite project reference. A rename in Daylite will therefore split a project's history across two titles, which is accepted for this change.
+- No highlighting of the matching cards after the jump. `highlight-matching-events` owns card marking and stays independent.
+- No absence search. Absence calendars are not requested.
+- No search as the planner types, no result paging, and no widening of the range from within the modal.
+- No caching of search results.
+
+## Decisions
+
+### Filter titles in Rust, not on the CalDAV server
+Issue one `REPORT` per employee primary calendar carrying only the `time-range` filter already in `build_report_body`, and match titles in Rust over the parsed events.
+
+Alternative considered: adding a `prop-filter` on `SUMMARY` with a `text-match` so the server filters.
+Rejected on two counts.
+Its default collation `i;ascii-casemap` does not case-fold beyond ASCII, so a search for `müller` would miss `Müller` in an application whose data is German throughout; `i;unicode-casemap` is not reliably implemented.
+And a server that does not implement `prop-filter` returns the unfiltered calendar rather than an error, so a broken filter is indistinguishable from a working one until the results are wrong.
+Matching locally costs one range response per employee, which is the same request count either way, and makes the matching rule ours to test.
+
+### Case-insensitive substring matching
+A title matches when the query, trimmed and lowercased, is contained in the title lowercased, using Rust's Unicode-aware `to_lowercase`.
+An empty or whitespace-only query is not searched.
+
+Alternative considered: word-prefix or fuzzy matching.
+Rejected as unneeded for titles that are short project names, and as a rule that is harder to explain than "contains".
+
+### Search on submit, not while typing
+The modal searches when the planner submits the field.
+`useAssignmentProjectSearch` debounces and requires three characters because it queries Daylite on every keystroke; a search that fans out over every employee's year of calendar data must not fire on a keystroke at all.
+Submitting also removes the minimum-length rule: a deliberate two-character search is the planner's to make.
+
+### Fixed range of one year back and one year forward
+The backend derives the range from today.
+
+Alternative considered: an unbounded query, by omitting `time-range`.
+Rejected because it makes the response size a property of the server's history rather than of the request.
+
+Alternative considered: a range the planner widens from the modal.
+Rejected for this change as scope that is only worth adding once the fixed range is shown to be too narrow in use.
+The modal states the searched range so a miss is not read as an absence of the event.
+
+### The frontend chooses which employees are searched
+The command takes the employee references to search, and the frontend passes exactly the employees the grid is currently showing.
+
+Alternative considered: searching every employee with a configured primary calendar, as `load_week_events` does.
+Rejected because a result for an employee hidden by `hideNonPlannableEmployees` would jump the grid to a week where the matching card is not rendered.
+Keeping the searched set equal to the displayed set means every result is reachable.
+
+### Absolute week jump
+Add a helper to `src/app/util.ts` that turns a date into the `weekOffset` whose week contains it, and let the modal set `weekOffset` directly in `src/app.tsx`.
+`onNavigateWeek` steps by one week and is kept as is for the arrow and swipe navigation it already serves.
+
+### Per-employee errors
+The command returns the hits it has plus the employees it could not read, mirroring how `load_week_events` reports a per-employee failure rather than failing the whole load.
+The modal names the failed employees in German above the results.
+
+## Risks / Trade-offs
+
+- [A year of events per employee in one response, where the grid fetches a week] → The fan-out is one request per employee, not one per week, and a search is a deliberate, occasional action rather than something navigation triggers. The modal shows a loading state while it runs.
+- [A project renamed in Daylite is findable only under the title stored on each event] → Accepted. The events carry the title they were written with, and searching by project reference is deliberately out of scope here.
+- [The searched range silently excludes older history] → Mitigated by stating the range in the modal, so an empty result reads as "not in this range" rather than "not scheduled".
+
+## Relationship to `caldav-caching-improvements`
+
+The two changes are independent, and neither blocks the other.
+
+That change caches resolved week events keyed by `(employee_id, calendar_url, week_start)`, to spare repeated identical fetches during week navigation.
+A search does not fit that cache in either direction.
+It reads a range that is not a week, so it cannot look entries up; and its results are a title-filtered subset, so writing them under a week key would leave the grid rendering a week with most of its events missing.
+Search therefore bypasses the cache entirely, and the code must not be tempted to share the key space.
+
+The one piece of that change search does depend on has already landed outside it: the shared `caldav_client()` reached through `build_caldav_session`, which gives the search fan-out connection reuse without any further work.
+
+## Open Questions
+
+None.

--- a/openspec/changes/search-events-by-title/proposal.md
+++ b/openspec/changes/search-events-by-title/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+A planner who needs to know when a job was last on site, or when it is next scheduled, has no way to ask.
+The grid shows one week, and the only way to reach another week is to navigate into it and read it.
+Finding a single past appointment means paging backwards a week at a time and scanning every row on the way.
+
+The `highlight-matching-events` change answers the neighbouring question, "where else is this work in the week I am looking at", by picking a card.
+It cannot answer "when else", because the data it marks is the data already on screen.
+Reaching beyond the visible week takes a query the planner types and a result list that names dates, which is what every calendar application offers and this one does not.
+
+## What Changes
+
+- A search button in the application header opens a search modal.
+- The planner types a title fragment and submits it.
+  Submitting runs the search; the field does not search while typing.
+- The search matches event titles, case-insensitively, anywhere in the title.
+  Matching is Unicode-aware, so a query typed without capitals still finds `Müller`.
+- The search covers assignments and bare events on the primary calendars of the employees the grid is currently showing.
+  Absence calendars are not read at all, so an absence is never a result.
+- The searched range is one year back and one year forward from today.
+  The modal states the range, so the planner knows what was looked at.
+- Results are listed oldest first, each naming its date, weekday, employee, time and title.
+- Clicking a result jumps the grid to the week holding that date and closes the modal.
+- Employees whose calendar could not be read are reported in the modal by name, and the results found for the others are still shown.
+
+## Capabilities
+
+### New Capabilities
+
+- `event-search`: finding events by title across a range of weeks and jumping the grid to a result's week.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `src-tauri/src/integrations/calendar/caldav/report.rs`: no change.
+  `fetch_events_in_range` already takes an arbitrary range; only the week-shaped wrapper is specific to the grid.
+- `src-tauri/src/integrations/calendar/commands.rs`: a new `search_events_by_title` command, fanning out over the given employees' primary calendars with the existing shared `caldav_client()` and the existing concurrency bound.
+- `src-tauri/src/integrations/calendar/types.rs`: an `EventSearchHit` type carrying the date, employee reference, title and times of one match.
+- `src/generated/tauri.ts`: regenerated bindings for the new command and type.
+- `src/app/util.ts`: a helper turning a date into the week offset that shows it, so a result can be jumped to.
+- `src/app.tsx`: the search button, the modal's open state, and the absolute week jump.
+  `onNavigateWeek` is relative by one week and cannot express the jump.
+- `src/app/components/event-search-dialog.tsx`: the modal, its query field, its result list and its error reporting.
+- No interaction with `caldav-caching-improvements`.
+  That change caches week-shaped reads for the grid; a search reads an arbitrary range and neither reads from nor writes to that cache.
+- Tests: `cargo test` for the title matching and the range derivation, `bun test` for the week-offset helper, the result list, the jump and the partial-error reporting.

--- a/openspec/changes/search-events-by-title/specs/event-search/spec.md
+++ b/openspec/changes/search-events-by-title/specs/event-search/spec.md
@@ -1,0 +1,160 @@
+## ADDED Requirements
+
+### Requirement: Opening the search
+The system SHALL offer a search button in the application header that opens a search modal.
+The modal SHALL hold a query field, and SHALL be dismissable without changing the week the grid shows.
+
+#### Scenario: The header offers a search button
+- **WHEN** the application is rendered
+- **THEN** the header includes a search button carrying a German label
+
+#### Scenario: The button opens the modal
+- **WHEN** the user activates the search button
+- **THEN** the search modal is shown with an empty query field
+
+#### Scenario: Dismissing leaves the grid alone
+- **GIVEN** the search modal is open
+- **WHEN** the user dismisses it without choosing a result
+- **THEN** the grid shows the same week it showed before
+
+### Requirement: Running a search
+The system SHALL search only when the query is submitted, and SHALL NOT search while the query is being typed.
+A query that is empty or only whitespace SHALL NOT be searched.
+
+#### Scenario: Typing does not search
+- **GIVEN** the search modal is open
+- **WHEN** the user types into the query field without submitting
+- **THEN** no search is run
+
+#### Scenario: Submitting searches
+- **GIVEN** a query has been typed
+- **WHEN** the user submits it
+- **THEN** a search for that query is run
+
+#### Scenario: A blank query is not searched
+- **WHEN** the user submits an empty or whitespace-only query
+- **THEN** no search is run and no results are shown
+
+#### Scenario: The search reports that it is running
+- **WHEN** a search is running
+- **THEN** the modal shows a loading state until the results arrive
+
+### Requirement: Title matching
+The system SHALL treat an event as a match when the submitted query, trimmed and lowercased, occurs anywhere in the event's title lowercased.
+Lowercasing SHALL be Unicode-aware, so that a query matches a title differing from it only in capitalisation of a non-ASCII letter.
+
+#### Scenario: A fragment matches
+- **GIVEN** an event titled `Neubau Müller`
+- **WHEN** the user searches for `bau`
+- **THEN** that event is a result
+
+#### Scenario: Capitalisation is ignored
+- **GIVEN** an event titled `Neubau Müller`
+- **WHEN** the user searches for `müller`
+- **THEN** that event is a result
+
+#### Scenario: Capitalisation of a non-ASCII letter is ignored
+- **GIVEN** an event titled `Ökobau`
+- **WHEN** the user searches for `ökobau`
+- **THEN** that event is a result
+
+#### Scenario: Surrounding whitespace is ignored
+- **GIVEN** an event titled `Neubau Müller`
+- **WHEN** the user searches for `  Müller  `
+- **THEN** that event is a result
+
+#### Scenario: A title that does not contain the query is not a result
+- **GIVEN** an event titled `Neubau Müller`
+- **WHEN** the user searches for `Schmidt`
+- **THEN** that event is not a result
+
+### Requirement: Search scope
+The system SHALL search the primary calendars of exactly the employees the grid is currently showing, and SHALL NOT read any absence calendar.
+The searched range SHALL be one year before to one year after the current date, and the modal SHALL state that range.
+
+#### Scenario: Assignments and bare events are searched
+- **GIVEN** an assignment and a bare event whose titles both contain the query
+- **WHEN** the search is run
+- **THEN** both are results
+
+#### Scenario: Absences are never results
+- **GIVEN** an absence whose title contains the query
+- **WHEN** the search is run
+- **THEN** it is not a result
+
+#### Scenario: Hidden employees are not searched
+- **GIVEN** an employee the grid is hiding has an event whose title contains the query
+- **WHEN** the search is run
+- **THEN** that event is not a result
+
+#### Scenario: Past and future weeks are searched
+- **GIVEN** matching events in a week before and a week after the current week
+- **WHEN** the search is run
+- **THEN** both are results
+
+#### Scenario: Events outside the range are not results
+- **GIVEN** a matching event more than a year before the current date
+- **WHEN** the search is run
+- **THEN** it is not a result
+
+#### Scenario: The searched range is stated
+- **WHEN** the results are shown
+- **THEN** the modal states the range that was searched
+
+### Requirement: Result list
+The system SHALL list the results oldest first, each naming its date, its weekday, the employee, the event's time and the event's title.
+An all-day event SHALL be listed without a time rather than with an empty one.
+
+#### Scenario: Results are ordered oldest first
+- **GIVEN** matching events on several dates
+- **WHEN** the results are shown
+- **THEN** they are listed in ascending date order
+
+#### Scenario: A result names its event
+- **WHEN** a result is shown
+- **THEN** it names the date, the weekday, the employee, the time and the title of the matching event
+
+#### Scenario: An all-day result shows no time
+- **GIVEN** a matching event without a start time
+- **WHEN** its result is shown
+- **THEN** it is listed without a time
+
+#### Scenario: No match is reported
+- **GIVEN** a query matching no event in the searched range
+- **WHEN** the search completes
+- **THEN** the modal reports in German that nothing was found, and states the range that was searched
+
+### Requirement: Jumping to a result
+The system SHALL show the week containing a chosen result and close the modal.
+
+#### Scenario: Choosing a result shows its week
+- **GIVEN** results are shown
+- **WHEN** the user chooses one
+- **THEN** the grid shows the week containing that result's date
+
+#### Scenario: Choosing a result closes the modal
+- **WHEN** the user chooses a result
+- **THEN** the search modal is closed
+
+#### Scenario: Choosing a result in the current week keeps the week
+- **GIVEN** a result whose date falls in the week already shown
+- **WHEN** the user chooses it
+- **THEN** the grid still shows that week and the modal is closed
+
+### Requirement: Partial failures
+The system SHALL show the results it found when some employees' calendars could not be read, and SHALL name those employees in German.
+
+#### Scenario: A failed calendar does not discard the other results
+- **GIVEN** one employee's calendar cannot be read and another's holds a matching event
+- **WHEN** the search is run
+- **THEN** the matching event is shown as a result
+
+#### Scenario: Failed employees are named
+- **GIVEN** an employee's calendar could not be read
+- **WHEN** the results are shown
+- **THEN** the modal names that employee in a German message
+
+#### Scenario: A search that fails entirely is reported
+- **GIVEN** no employee's calendar can be read
+- **WHEN** the search is run
+- **THEN** the modal shows a German error message and no results

--- a/openspec/changes/search-events-by-title/tasks.md
+++ b/openspec/changes/search-events-by-title/tasks.md
@@ -1,0 +1,41 @@
+## 1. Backend title matching
+
+- [ ] 1.1 Write failing `cargo test`s for the title match rule: substring, case-insensitive, non-ASCII case folding, trimmed query, blank query matches nothing
+- [ ] 1.2 Implement the match rule in `src-tauri/src/integrations/calendar/events/`, satisfying the tests
+- [ ] 1.3 Write failing `cargo test`s for the searched range derived from a given current date, covering the one-year bounds
+- [ ] 1.4 Implement the range derivation, satisfying the tests
+
+## 2. Search command
+
+- [ ] 2.1 Add an `EventSearchHit` type in `src-tauri/src/integrations/calendar/types.rs` carrying uid, employee reference, date, start time, end time and title
+- [ ] 2.2 Write failing `cargo test`s for assembling a search result from per-employee fetches, covering ascending date order, absences excluded, and per-employee errors kept beside the hits
+- [ ] 2.3 Implement `search_events_by_title` in `src-tauri/src/integrations/calendar/commands.rs`, taking the query and the employee references, fanning out over primary calendars only via `fetch_events_in_range` and the shared `caldav_client()`, satisfying the tests
+- [ ] 2.4 Register the command in `specta_builder()` and regenerate `src/generated/tauri.ts`
+
+## 3. Week jump helper
+
+- [ ] 3.1 Write failing `bun test`s in `src/app/util.spec.ts` for a helper turning a date into the week offset showing it, covering the current week, past and future weeks, and a Monday and a Sunday boundary
+- [ ] 3.2 Implement the helper in `src/app/util.ts`, satisfying the tests
+
+## 4. Search modal
+
+- [ ] 4.1 Write a failing `bun test` that the modal runs no search while the query is typed and runs one on submit, and none for a blank query
+- [ ] 4.2 Implement the query field and submit handling in `src/app/components/event-search-dialog.tsx`, satisfying the tests
+- [ ] 4.3 Write failing tests for the result list: ascending order, a result naming date, weekday, employee, time and title, an all-day result without a time
+- [ ] 4.4 Implement the result list, satisfying the tests
+- [ ] 4.5 Write failing tests for the loading state, the no-match message and the stated searched range
+- [ ] 4.6 Implement those states, satisfying the tests
+- [ ] 4.7 Write failing tests for partial failures: results still shown, failed employees named, a fully failed search reported
+- [ ] 4.8 Implement the error reporting, satisfying the tests
+
+## 5. Wiring
+
+- [ ] 5.1 Write a failing test that choosing a result shows that result's week and closes the modal
+- [ ] 5.2 Add the header search button and the modal's open state to `src/app.tsx`, and set `weekOffset` from the chosen result, satisfying the test
+- [ ] 5.3 Pass the currently displayed employees to the search, so hidden employees are not searched
+
+## 6. Checks
+
+- [ ] 6.1 Run `bun test` and `cargo test`
+- [ ] 6.2 Run `bun run lint`
+- [ ] 6.3 Run `bunx openspec validate search-events-by-title`


### PR DESCRIPTION
## Description

Adds the OpenSpec change `search-events-by-title` for finding events across past and future weeks.

A search button in the header opens a modal.
The planner submits a title fragment, gets a list of matches ordered oldest first, and clicking one jumps the grid to that result's week.
Search covers assignments and bare events on the primary calendars of the employees the grid is currently showing; absence calendars are not read at all.
The searched range is one year back and one year forward from today, and the modal states that range.

This is planning only: proposal, design, delta spec for the new `event-search` capability, and tasks.
No application code changes.

### Notable decisions

Titles are matched in Rust rather than by a CalDAV `prop-filter`.
The `text-match` default collation `i;ascii-casemap` does not case-fold beyond ASCII, so a search for `müller` would miss `Müller` in an application whose data is German throughout, and a server that does not implement `prop-filter` returns the unfiltered calendar rather than an error.
Matching locally costs the same request count and makes the rule ours to test.

The search runs on submit rather than while typing, because a fan-out over every displayed employee's year of calendar data must not fire on a keystroke.
Submitting also removes the need for a minimum query length.

The command takes the employee references to search and the frontend passes the employees the grid is showing, so a result is never in a week where its card is hidden.

The range is fixed rather than widenable from the modal, and the modal states it so an empty result reads as "not in this range" rather than "not scheduled".

This change is independent of `caldav-caching-improvements` and neither blocks the other.
That change caches week-shaped reads; a search reads an arbitrary range, so it cannot look entries up, and its results are a title-filtered subset, so writing them under a week key would leave the grid rendering a week with most of its events missing.
Search bypasses that cache entirely.
The one piece it depends on, the shared `caldav_client()`, has already landed.

It is also independent of `highlight-matching-events`, which answers the same question within the visible week by picking a card.
Jumping to a result does not highlight anything.

### What to look out for

`fetch_events_in_range` already takes an arbitrary range, so no CalDAV transport change is needed; only a new command above it.

`onNavigateWeek` steps by one week and cannot express the jump, so `src/app.tsx` sets `weekOffset` directly from the chosen result.

Searching by Daylite project reference is deliberately out of scope, so a project renamed in Daylite is findable only under the title stored on each event.

## Reviewer checklist

- [ ] Read `openspec/changes/search-events-by-title/proposal.md` and confirm the scope matches the intent
- [ ] Read `design.md` and confirm the local-matching, submit-to-search, fixed-range and displayed-employees decisions
- [ ] Read `specs/event-search/spec.md` and confirm the scenarios cover the behaviour you expect
- [ ] Run `bunx openspec validate search-events-by-title`

---
_Generated by [Claude Code](https://claude.ai/code/session_013jQiiYrQrZShxUm6s5Tw98)_